### PR TITLE
remove metric

### DIFF
--- a/example.config.json
+++ b/example.config.json
@@ -1,6 +1,5 @@
 {
   "token": "<myapitoken>",
   "start_date": "2018-01-01T00:00:00Z",
-  "metric": "team_table",
   "incremental_range": "daily"
 }

--- a/tap_frontapp/__init__.py
+++ b/tap_frontapp/__init__.py
@@ -11,7 +11,7 @@ from . import streams
 from .context import Context
 from . import schemas
 
-REQUIRED_CONFIG_KEYS = ["token", "metric"]
+REQUIRED_CONFIG_KEYS = ["token"]
 
 LOGGER = singer.get_logger()
 

--- a/tap_frontapp/http.py
+++ b/tap_frontapp/http.py
@@ -19,7 +19,6 @@ class Client(object):
 
     def __init__(self, config):
         self.token = 'Bearer ' + config.get('token')
-        self.metric = config.get('metric')
         self.session = requests.Session()
 
         self.calls_remaining = None


### PR DESCRIPTION
The `metric` config param was unused.

This PR removes any reference of it.