### PR TITLE
Increase sleep between requests to /analytics endpoint from 1 to 3 seconds

### DIFF
--- a/tap_frontapp/streams.py
+++ b/tap_frontapp/streams.py
@@ -16,7 +16,7 @@ from .http import MetricsRateLimitException
 LOGGER = singer.get_logger()
 
 MAX_METRIC_JOB_TIME = 1800
-METRIC_JOB_POLL_SLEEP = 1
+METRIC_JOB_POLL_SLEEP = 3
 
 def count(tap_stream_id, records):
     with singer.metrics.record_counter(tap_stream_id) as counter:


### PR DESCRIPTION
# Description of change
Increases the sleep time between requests to Front's `/analytics` endpoint from 1 to 3 seconds.
This helps significantly reduce the number of API requests made to Front, reducing the risk of hitting the API rate limit, while adding at most 2-3 seconds additional latency between the analytics job being completed, and this app fetching the results.

# Manual QA steps
 - 
 
# Risks
 - Seems low risk. 
 
# Rollback steps
 - revert this branch
