### PR TITLE
Fix frontapp aggregated row handling

### DIFF
--- a/tap_frontapp/streams.py
+++ b/tap_frontapp/streams.py
@@ -93,61 +93,43 @@ def sync_metric(atx, metric, incremental_range, start_date, end_date):
     data_rows = []
     # transform the team_table data
     if metric == 'team_table':
-        rnum = 0
         for row in data:
-            rnum += 1
-            # the first row returned from frontapp is an aggregate row
+
+            # One of the row returned from frontapp is an aggregate row
             # and has a slightly different form
-            if rnum == 1:
-                data_rows.append({
-                    "analytics_date": start_date_formatted,
-                    "analytics_range": incremental_range,
-                    "teammate_v": row[0]['v'],
-                    "teammate_url": "",
-                    "teammate_id": 0,
-                    "teammate_p": row[0]['p'],
-                    "num_conversations_v": row[1]['v'],
-                    "num_conversations_p": row[1]['p'],
-                    "avg_message_conversations_v": row[2]['v'],
-                    "avg_message_conversations_p": row[2]['p'],
-                    "avg_reaction_time_v": row[3]['v'],
-                    "avg_reaction_time_p": row[3]['p'],
-                    "avg_first_reaction_time_v": row[4]['v'],
-                    "avg_first_reaction_time_p": row[4]['p'],
-                    "num_messages_v": row[5]['v'],
-                    "num_messages_p": row[5]['p'],
-                    "num_sent_v": row[6]['v'],
-                    "num_sent_p": row[6]['p'],
-                    "num_replied_v": row[7]['v'],
-                    "num_replied_p": row[7]['p'],
-                    "num_composed_v": row[8]['v'],
-                    "num_composed_p": row[8]['p']
-                    })
-            else:
-                data_rows.append({
-                    "analytics_date": start_date_formatted,
-                    "analytics_range": incremental_range,
-                    "teammate_v": row[0]['v'],
-                    "teammate_url": row[0]['url'],
-                    "teammate_id": row[0]['id'],
-                    "teammate_p": row[0]['v'],
-                    "num_conversations_v": row[1]['v'],
-                    "num_conversations_p": row[1]['p'],
-                    "avg_message_conversations_v": row[2]['v'],
-                    "avg_message_conversations_p": row[2]['p'],
-                    "avg_reaction_time_v": row[3]['v'],
-                    "avg_reaction_time_p": row[3]['p'],
-                    "avg_first_reaction_time_v": row[4]['v'],
-                    "avg_first_reaction_time_p": row[4]['p'],
-                    "num_messages_v": row[5]['v'],
-                    "num_messages_p": row[5]['p'],
-                    "num_sent_v": row[6]['v'],
-                    "num_sent_p": row[6]['p'],
-                    "num_replied_v": row[7]['v'],
-                    "num_replied_p": row[7]['p'],
-                    "num_composed_v": row[8]['v'],
-                    "num_composed_p": row[8]['p']
-                    })
+            if not 'url' in row[0]:
+                row[0]['url'] = ""
+
+            if not 'id' in row[0]:
+                row[0]['id'] = 0
+
+            if not 'p' in row[0]:
+                row[0]['p'] = row[0]['v']
+
+            data_rows.append({
+                "analytics_date": start_date_formatted,
+                "analytics_range": incremental_range,
+                "teammate_v": row[0]['v'],
+                "teammate_url": row[0]['url'],
+                "teammate_id": row[0]['id'],
+                "teammate_p": row[0]['p'],
+                "num_conversations_v": row[1]['v'],
+                "num_conversations_p": row[1]['p'],
+                "avg_message_conversations_v": row[2]['v'],
+                "avg_message_conversations_p": row[2]['p'],
+                "avg_reaction_time_v": row[3]['v'],
+                "avg_reaction_time_p": row[3]['p'],
+                "avg_first_reaction_time_v": row[4]['v'],
+                "avg_first_reaction_time_p": row[4]['p'],
+                "num_messages_v": row[5]['v'],
+                "num_messages_p": row[5]['p'],
+                "num_sent_v": row[6]['v'],
+                "num_sent_p": row[6]['p'],
+                "num_replied_v": row[7]['v'],
+                "num_replied_p": row[7]['p'],
+                "num_composed_v": row[8]['v'],
+                "num_composed_p": row[8]['p']
+                })
 
     write_records(metric, data_rows)
 


### PR DESCRIPTION
# Description of change

Fix #9 

The "aggregated" row of frontapp analytics API is not always at the beginning
of the returned rows.

In some cases, it is at the end of the array.

Hence, we change a little the logic to apply the "default" values when needed,
regardless of where we are in the returned array to be more robust.

# Manual QA steps
 - Test it against a live front integration

Example of run:
```
INFO PostgresTarget created with established connection: `user=postgres password=xxx dbname=xxx host=xxx port=5432`, PostgreSQL schema: `xxxx`\n'
INFO Sending version information to singer.io. To disable sending anonymous usage data, set the config parameter "disable_collection" to true\n'
INFO metric: team_table \n'
INFO start_date: 2020-05-03T00:00:00+00:00 \n'
INFO end_date: 2020-05-11T00:00:00+00:00 \n'
INFO last_date: 2020-05-10T00:00:00+00:00 \n'
INFO ut_current_date: 1589068800 \n'
INFO ut_next_date: 1589155200 \n'
INFO Metrics query - metric: team_table start_date: 1589068800 end_date: 1589155200 \n'
tbeat]
 Time since last heartbeat(0.03 s) < heartrate(5.0 s), sleeping for 4.974179 s
INFO METRIC: {"type": "timer", "metric": "http_request_duration", "value": 3.0623939037323, "tags": {"endpoint": "analytics", "http_status_code": 200, "status": "succeeded"}}\n'
INFO METRIC: {"type": "timer", "metric": "job_duration", "value": 3.0643279552459717, "tags": {"job_type": "daily_aggregated_metric", "status": "succeeded"}}\n'
INFO METRIC: {"type": "counter", "metric": "record_count", "value": 2, "tags": {"endpoint": "team_table"}}\n'
INFO ut_current_date: 1589155200 \n'
INFO ut_next_date: 1589241600 \n'
INFO Metrics query - metric: team_table start_date: 1589155200 end_date: 1589241600 \n'
INFO METRIC: {"type": "timer", "metric": "http_request_duration", "value": 2.4145939350128174, "tags": {"endpoint": "analytics", "http_status_code": 200, "status": "succeeded"}}\n'
INFO METRIC: {"type": "timer", "metric": "job_duration", "value": 2.4174392223358154, "tags": {"job_type": "daily_aggregated_metric", "status": "succeeded"}}\n'
INFO METRIC: {"type": "counter", "metric": "record_count", "value": 0, "tags": {"endpoint": "team_table"}}\n'
INFO Stream team_table (team_table) with max_version None targetting None\n'
INFO Root table name team_table\n'
INFO Writing batch with 2 records for `team_table` with `key_properties`: `['analytics_date', 'analytics_range', 'teammate_v']`\n"
INFO Writing table batch schema for `('team_table',)`...\n"
INFO Table Schema Change [`team_table`.`('analytics_date',)`:`analytics_date`] New column (took 10 millis)\n"
INFO Table Schema Change [`team_table`.`('analytics_range',)`:`analytics_range`] New column (took 6 millis)\n"
INFO Table Schema Change [`team_table`.`('teammate_v',)`:`teammate_v`] New column (took 6 millis)\n"
INFO Table Schema Change [`team_table`.`('teammate_url',)`:`teammate_url`] New column (took 4 millis)\n"
INFO Table Schema Change [`team_table`.`('teammate_id',)`:`teammate_id`] New column (took 5 millis)\n"
INFO Table Schema Change [`team_table`.`('teammate_p',)`:`teammate_p`] New column (took 5 millis)\n"
INFO Table Schema Change [`team_table`.`('num_conversations_v',)`:`num_conversations_v`] New column (took 2 millis)\n"
INFO Table Schema Change [`team_table`.`('num_conversations_p',)`:`num_conversations_p`] New column (took 3 millis)\n"
INFO Table Schema Change [`team_table`.`('avg_message_conversations_v',)`:`avg_message_conversations_v`] New column (took 2 millis)\n"
INFO Table Schema Change [`team_table`.`('avg_message_conversations_p',)`:`avg_message_conversations_p`] New column (took 2 millis)\n"
INFO Table Schema Change [`team_table`.`('avg_reaction_time_v',)`:`avg_reaction_time_v`] New column (took 2 millis)\n"
INFO Table Schema Change [`team_table`.`('avg_reaction_time_p',)`:`avg_reaction_time_p`] New column (took 2 millis)\n"
INFO Table Schema Change [`team_table`.`('avg_first_reaction_time_v',)`:`avg_first_reaction_time_v`] New column (took 2 millis)\n"
INFO Table Schema Change [`team_table`.`('avg_first_reaction_time_p',)`:`avg_first_reaction_time_p`] New column (took 2 millis)\n"
INFO Table Schema Change [`team_table`.`('num_messages_v',)`:`num_messages_v`] New column (took 2 millis)\n"
INFO Table Schema Change [`team_table`.`('num_messages_p',)`:`num_messages_p`] New column (took 2 millis)\n"
INFO Table Schema Change [`team_table`.`('num_sent_v',)`:`num_sent_v`] New column (took 2 millis)\n"
INFO Table Schema Change [`team_table`.`('num_sent_p',)`:`num_sent_p`] New column (took 2 millis)\n"
INFO Table Schema Change [`team_table`.`('num_replied_v',)`:`num_replied_v`] New column (took 2 millis)\n"
INFO Table Schema Change [`team_table`.`('num_replied_p',)`:`num_replied_p`] New column (took 2 millis)\n"
INFO Table Schema Change [`team_table`.`('num_composed_v',)`:`num_composed_v`] New column (took 2 millis)\n"
INFO Table Schema Change [`team_table`.`('num_composed_p',)`:`num_composed_p`] New column (took 2 millis)\n"
INFO Table Schema Change [`team_table`.`('_sdc_received_at',)`:`_sdc_received_at`] New column (took 3 millis)\n"
INFO Table Schema Change [`team_table`.`('_sdc_sequence',)`:`_sdc_sequence`] New column (took 2 millis)\n"
INFO Table Schema Change [`team_table`.`('_sdc_table_version',)`:`_sdc_table_version`] New column (took 2 millis)\n"
INFO Table Schema Change [`team_table`.`('_sdc_batched_at',)`:`_sdc_batched_at`] New column (took 3 millis)\n"
INFO METRIC: {"type": "timer", "metric": "job_duration", "value": 0.18404507637023926, "tags": {"job_type": "upsert_table_schema", "path": ["team_table"], "database": "xxxx", "schema": "xxxx", "table": "team_table", "status": "succeeded"}}\n'
INFO Writing table batch with 2 rows for `('team_table',)`...\n"
INFO METRIC: {"type": "counter", "metric": "record_count", "value": 2, "tags": {"count_type": "table_rows_persisted", "path": ["team_table"], "database": "xxxx", "schema": "xxxx", "table": "team_table"}}\n'
INFO METRIC: {"type": "timer", "metric": "job_duration", "value": 0.21413373947143555, "tags": {"job_type": "table", "path": ["team_table"], "database": "xxxx", "schema": "xxxx", "table": "team_table", "status": "succeeded"}}\n'
INFO METRIC: {"type": "counter", "metric": "record_count", "value": 2, "tags": {"count_type": "batch_rows_persisted", "path": ["team_table"], "database": "xxxx", "schema": "xxxx"}}\n'
INFO METRIC: {"type": "timer", "metric": "job_duration", "value": 0.21940231323242188, "tags": {"job_type": "batch", "path": ["team_table"], "database": "xxxx", "schema": "xxxx", "status": "succeeded"}}\n'
``` 

![image](https://user-images.githubusercontent.com/4692633/81540654-3f8d4880-9372-11ea-8004-297c98362f09.png)

# Risks
 - None identified
 
# Rollback steps
 - revert this branch
