### PR TITLE
Add analytics tables streams

### DIFF
--- a/tap_frontapp/schemas.py
+++ b/tap_frontapp/schemas.py
@@ -7,15 +7,36 @@ from singer import utils
 class IDS(object): # pylint: disable=too-few-public-methods
     TEAM_TABLE = 'team_table'
     TAGS_TABLE = 'tags_table'
+    CUSTOMERS_TABLE = 'customers_table'
+    FIRST_RESPONSE_HISTO = 'first_response_histo'
+    RESOLUTION_HISTO = 'resolution_histo'
+    RESPONSE_HISTO = 'response_histo'
+    TOP_CONVERSATION_TABLE = 'top_conversations_table'
+    TOP_REACTION_TIME_TABLE = 'top_reaction_time_table'
+    TOP_REPLIES_TABLE = 'top_replies_table'
 
 STATIC_SCHEMA_STREAM_IDS = [
     IDS.TEAM_TABLE,
-    IDS.TAGS_TABLE
+    IDS.TAGS_TABLE,
+    IDS.CUSTOMERS_TABLE,
+    IDS.FIRST_RESPONSE_HISTO,
+    IDS.RESOLUTION_HISTO,
+    IDS.RESPONSE_HISTO,
+    IDS.TOP_CONVERSATION_TABLE,
+    IDS.TOP_REACTION_TIME_TABLE,
+    IDS.TOP_REPLIES_TABLE
 ]
 
 PK_FIELDS = {
     IDS.TEAM_TABLE: ['analytics_date', 'analytics_range', 'teammate_v'],
-    IDS.TAGS_TABLE: ['analytics_date', 'analytics_range', 'tag_v']
+    IDS.TAGS_TABLE: ['analytics_date', 'analytics_range', 'tag_v'],
+    IDS.CUSTOMERS_TABLE: ['analytics_date', 'analytics_range', 'resource_t', 'resource_v'],
+    IDS.FIRST_RESPONSE_HISTO: ['analytics_date', 'analytics_range', 'time_v'],
+    IDS.RESOLUTION_HISTO: ['analytics_date', 'analytics_range', 'time_v'],
+    IDS.RESPONSE_HISTO: ['analytics_date', 'analytics_range', 'time_v'],
+    IDS.TOP_CONVERSATION_TABLE: ['analytics_date', 'analytics_range', 'teammate_v'],
+    IDS.TOP_REACTION_TIME_TABLE: ['analytics_date', 'analytics_range', 'teammate_v'],
+    IDS.TOP_REPLIES_TABLE: ['analytics_date', 'analytics_range', 'teammate_v']
 }
 
 def normalize_fieldname(fieldname):

--- a/tap_frontapp/schemas.py
+++ b/tap_frontapp/schemas.py
@@ -6,13 +6,16 @@ from singer import utils
 
 class IDS(object): # pylint: disable=too-few-public-methods
     TEAM_TABLE = 'team_table'
+    TAGS_TABLE = 'tags_table'
 
 STATIC_SCHEMA_STREAM_IDS = [
-    IDS.TEAM_TABLE
+    IDS.TEAM_TABLE,
+    IDS.TAGS_TABLE
 ]
 
 PK_FIELDS = {
-    IDS.TEAM_TABLE: ['analytics_date', 'analytics_range', 'teammate_v']
+    IDS.TEAM_TABLE: ['analytics_date', 'analytics_range', 'teammate_v'],
+    IDS.TAGS_TABLE: ['analytics_date', 'analytics_range', 'tag_v']
 }
 
 def normalize_fieldname(fieldname):

--- a/tap_frontapp/schemas/customers_table.json
+++ b/tap_frontapp/schemas/customers_table.json
@@ -39,7 +39,7 @@
         "resource_url": {
             "type": [
                 "null",
-                "integer"
+                "string"
             ]
         },
         "num_received_p": {
@@ -95,8 +95,8 @@
                 "null",
                 "number"
             ]
-    },
-    "avg_resolution_v": {
+        },
+        "avg_resolution_v": {
             "type": [
                 "null",
                 "number"

--- a/tap_frontapp/schemas/customers_table.json
+++ b/tap_frontapp/schemas/customers_table.json
@@ -1,0 +1,106 @@
+{
+    "type": [
+        "null",
+        "object"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "analytics_date": {
+            "type": [
+                "null",
+                "string"
+            ],
+            "format": "date"
+        },
+        "analytics_range": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "resource_t": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "resource_v": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "resource_id": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        },
+        "resource_url": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        },
+        "num_received_p": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        },
+        "num_received_v": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        },
+        "num_sent_p": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        },
+        "num_sent_v": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        },
+        "avg_first_response_p": {
+            "type": [
+                "null",
+                "number"
+            ]
+        },
+        "avg_first_response_v": {
+            "type": [
+                "null",
+                "number"
+            ]
+        },
+        "avg_response_p": {
+            "type": [
+                "null",
+                "number"
+            ]
+        },
+        "avg_response_v": {
+            "type": [
+                "null",
+                "number"
+            ]
+        },
+        "avg_resolution_p": {
+            "type": [
+                "null",
+                "number"
+            ]
+    },
+    "avg_resolution_v": {
+            "type": [
+                "null",
+                "number"
+            ]
+        }
+    }
+}

--- a/tap_frontapp/schemas/first_response_histo.json
+++ b/tap_frontapp/schemas/first_response_histo.json
@@ -1,0 +1,40 @@
+{
+    "type": [
+        "null",
+        "object"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "analytics_date": {
+            "type": [
+                "null",
+                "string"
+            ],
+            "format": "date"
+        },
+        "analytics_range": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "time_v": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "replies_p": {
+            "type": [
+                "null",
+                "number"
+            ]
+        },
+        "replies_v": {
+            "type": [
+                "null",
+                "number"
+            ]
+        }
+    }
+}

--- a/tap_frontapp/schemas/resolution_histo.json
+++ b/tap_frontapp/schemas/resolution_histo.json
@@ -1,0 +1,40 @@
+{
+    "type": [
+        "null",
+        "object"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "analytics_date": {
+            "type": [
+                "null",
+                "string"
+            ],
+            "format": "date"
+        },
+        "analytics_range": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "time_v": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "resolutions_p": {
+            "type": [
+                "null",
+                "number"
+            ]
+        },
+        "resolutions_v": {
+            "type": [
+                "null",
+                "number"
+            ]
+        }
+    }
+}

--- a/tap_frontapp/schemas/response_histo.json
+++ b/tap_frontapp/schemas/response_histo.json
@@ -1,0 +1,40 @@
+{
+    "type": [
+        "null",
+        "object"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "analytics_date": {
+            "type": [
+                "null",
+                "string"
+            ],
+            "format": "date"
+        },
+        "analytics_range": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "time_v": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "replies_p": {
+            "type": [
+                "null",
+                "number"
+            ]
+        },
+        "replies_v": {
+            "type": [
+                "null",
+                "number"
+            ]
+        }
+    }
+}

--- a/tap_frontapp/schemas/tags_table.json
+++ b/tap_frontapp/schemas/tags_table.json
@@ -1,0 +1,100 @@
+{
+	"type": [
+		"null",
+		"object"
+	],
+	"additionalProperties": false,
+	"properties": {
+		"analytics_date": {
+			"type": [
+				"null",
+				"string"
+			],
+			"format": "date"
+		},
+		"analytics_range": {
+			"type": [
+				"null",
+				"string"
+			]
+		},
+		"tag_v": {
+			"type": [
+				"null",
+				"string"
+			]
+		},
+		"tag_url": {
+			"type": [
+				"null",
+				"string"
+			]
+		},
+		"tag_id": {
+			"type": [
+				"null",
+				"integer"
+			]
+		},
+		"conversations_archived_v": {
+			"type": [
+				"null",
+				"integer"
+			]
+		},
+		"conversations_archived_p": {
+			"type": [
+				"null",
+				"integer"
+			]
+		},
+		"conversations_open_v": {
+			"type": [
+				"null",
+				"number"
+			]
+		},
+		"conversations_open_p": {
+			"type": [
+				"null",
+				"number"
+			]
+		},
+		"conversations_total_v": {
+			"type": [
+				"null",
+				"number"
+			]
+		},
+		"conversations_total_p": {
+			"type": [
+				"null",
+				"number"
+			]
+		},
+		"num_messages_v": {
+			"type": [
+				"null",
+				"number"
+			]
+		},
+		"num_messages_p": {
+			"type": [
+				"null",
+				"number"
+			]
+		},
+		"avg_message_conversations_v": {
+			"type": [
+				"null",
+				"integer"
+			]
+		},
+		"avg_message_conversations_p": {
+			"type": [
+				"null",
+				"integer"
+			]
+		}
+	}
+}

--- a/tap_frontapp/schemas/tags_table.json
+++ b/tap_frontapp/schemas/tags_table.json
@@ -51,49 +51,49 @@
 		"conversations_open_v": {
 			"type": [
 				"null",
-				"number"
+				"integer"
 			]
 		},
 		"conversations_open_p": {
 			"type": [
 				"null",
-				"number"
+				"integer"
 			]
 		},
 		"conversations_total_v": {
 			"type": [
 				"null",
-				"number"
+				"integer"
 			]
 		},
 		"conversations_total_p": {
 			"type": [
 				"null",
-				"number"
+				"integer"
 			]
 		},
 		"num_messages_v": {
 			"type": [
 				"null",
-				"number"
+				"integer"
 			]
 		},
 		"num_messages_p": {
 			"type": [
 				"null",
-				"number"
+				"integer"
 			]
 		},
 		"avg_message_conversations_v": {
 			"type": [
 				"null",
-				"integer"
+				"number"
 			]
 		},
 		"avg_message_conversations_p": {
 			"type": [
 				"null",
-				"integer"
+				"number"
 			]
 		}
 	}

--- a/tap_frontapp/schemas/top_conversations_table.json
+++ b/tap_frontapp/schemas/top_conversations_table.json
@@ -1,0 +1,52 @@
+{
+    "type": [
+        "null",
+        "object"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "analytics_date": {
+            "type": [
+                "null",
+                "string"
+            ],
+            "format": "date"
+        },
+        "analytics_range": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "teammate_v": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "teammate_url": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "teammate_id": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        },
+        "num_conversations_p": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        },
+        "num_conversations_v": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        }
+    }
+}

--- a/tap_frontapp/schemas/top_reaction_time_table.json
+++ b/tap_frontapp/schemas/top_reaction_time_table.json
@@ -1,0 +1,52 @@
+{
+    "type": [
+        "null",
+        "object"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "analytics_date": {
+            "type": [
+                "null",
+                "string"
+            ],
+            "format": "date"
+        },
+        "analytics_range": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "teammate_v": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "teammate_url": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "teammate_id": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        },
+        "avg_reaction_time_p": {
+            "type": [
+                "null",
+                "number"
+            ]
+        },
+        "avg_reaction_time_v": {
+            "type": [
+                "null",
+                "number"
+            ]
+        }
+    }
+}

--- a/tap_frontapp/schemas/top_replies_table.json
+++ b/tap_frontapp/schemas/top_replies_table.json
@@ -1,0 +1,52 @@
+{
+    "type": [
+        "null",
+        "object"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "analytics_date": {
+            "type": [
+                "null",
+                "string"
+            ],
+            "format": "date"
+        },
+        "analytics_range": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "teammate_v": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "teammate_url": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "teammate_id": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        },
+        "num_replies_p": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        },
+        "num_replies_v": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        }
+    }
+}

--- a/tap_frontapp/streams.py
+++ b/tap_frontapp/streams.py
@@ -333,8 +333,6 @@ def sync_metrics(atx, metric):
         write_metrics_state(atx, metric, next_date)
         current_date = next_date
 
-    reset_stream(atx.state, metric)
-
 def sync_selected_streams(atx):
     selected_streams = atx.selected_stream_ids
 

--- a/tap_frontapp/streams.py
+++ b/tap_frontapp/streams.py
@@ -65,7 +65,7 @@ def select_fields(mdata, obj):
 @on_exception(constant, MetricsRateLimitException, max_tries=5, interval=60)
 @on_exception(expo, RateLimitException, max_tries=5)
 @sleep_and_retry
-@limits(calls=1, period=61) # 60 seconds needed to be padded by 1 second to work
+@limits(calls=1ß, period=61) # 60 seconds needed to be padded by 1 second to work
 def get_metric(atx, metric, start_date, end_date):
     LOGGER.info('Metrics query - metric: {} start_date: {} end_date: {} '.format(
         metric,
@@ -170,6 +170,105 @@ def sync_metric(atx, metric, incremental_range, start_date, end_date):
                 "avg_message_conversations_p": row[5]['p']
                 })
 
+    # transform the customers_table data
+    if metric == 'customers_table':
+        for row in data:
+
+            # Some resource (ex. of type 'contact') don't have URLs
+            if not 'url' in row[0]:
+                row[0]['url'] = None
+
+            data_rows.append({
+                "analytics_date": start_date_formatted,
+                "analytics_range": incremental_range,
+                "resource_t": row[0]['t'],
+                "resource_v": row[0]['v'],
+                "resource_id": row[0]['id'],
+                "resource_url": row[0]['url'],
+                "num_received_v": row[1]['v'],
+                "num_received_p": row[1]['p'],
+                "num_sent_v": row[2]['v'],
+                "num_sent_p": row[2]['p'],
+                "avg_first_response_v": row[3]['v'],
+                "avg_first_response_p": row[3]['p'],
+                "avg_response_v": row[4]['v'],
+                "avg_response_p": row[4]['p'],
+                "avg_resolution_v": row[5]['v'],
+                "avg_resolution_p": row[5]['p']
+                })
+
+    # transform the first_response_histo data
+    if metric == 'first_response_histo':
+        for row in data:
+            data_rows.append({
+                "analytics_date": start_date_formatted,
+                "analytics_range": incremental_range,
+                "time_v": row[0]['v'],
+                "replies_v": row[1]['v'],
+                "replies_p": row[1]['p']
+                })
+
+    # transform the resolution_histo data
+    if metric == 'resolution_histo':
+        for row in data:
+            data_rows.append({
+                "analytics_date": start_date_formatted,
+                "analytics_range": incremental_range,
+                "time_v": row[0]['v'],
+                "resolutions_v": row[1]['v'],
+                "resolutions_p": row[1]['p']
+                })
+
+    # transform the response_histo data
+    if metric == 'response_histo':
+        for row in data:
+            data_rows.append({
+                "analytics_date": start_date_formatted,
+                "analytics_range": incremental_range,
+                "time_v": row[0]['v'],
+                "replies_v": row[1]['v'],
+                "replies_p": row[1]['p']
+                })
+
+    # transform the top_conversations_table data
+    if metric == 'top_conversations_table':
+        for row in data:
+            data_rows.append({
+                "analytics_date": start_date_formatted,
+                "analytics_range": incremental_range,
+                "teammate_v": row[0]['v'],
+                "teammate_url": row[0]['url'],
+                "teammate_id": row[0]['id'],
+                "num_conversations_v": row[1]['v'],
+                "num_conversations_p": row[1]['p']
+                })
+
+    # transform the top_reaction_time_table data
+    if metric == 'top_reaction_time_table':
+        for row in data:
+            data_rows.append({
+                "analytics_date": start_date_formatted,
+                "analytics_range": incremental_range,
+                "teammate_v": row[0]['v'],
+                "teammate_url": row[0]['url'],
+                "teammate_id": row[0]['id'],
+                "avg_reaction_time_v": row[1]['v'],
+                "avg_reaction_time_p": row[1]['p']
+                })
+
+    # transform the top_replies_table data
+    if metric == 'top_replies_table':
+        for row in data:
+            data_rows.append({
+                "analytics_date": start_date_formatted,
+                "analytics_range": incremental_range,
+                "teammate_v": row[0]['v'],
+                "teammate_url": row[0]['url'],
+                "teammate_id": row[0]['id'],
+                "num_replies_v": row[1]['v'],
+                "num_replies_p": row[1]['p']
+                })
+
     write_records(metric, data_rows)
 
 def write_metrics_state(atx, metric, date_to_resume):
@@ -246,5 +345,26 @@ def sync_selected_streams(atx):
 
     if IDS.TAGS_TABLE in selected_streams:
         sync_metrics(atx, 'tags_table')
+
+    if IDS.CUSTOMERS_TABLE in selected_streams:
+        sync_metrics(atx, 'customers_table')
+
+    if IDS.FIRST_RESPONSE_HISTO in selected_streams:
+        sync_metrics(atx, 'first_response_histo')
+
+    if IDS.RESOLUTION_HISTO in selected_streams:
+        sync_metrics(atx, 'resolution_histo')
+
+    if IDS.RESPONSE_HISTO in selected_streams:
+        sync_metrics(atx, 'response_histo')
+
+    if IDS.TOP_CONVERSATION_TABLE in selected_streams:
+        sync_metrics(atx, 'top_conversations_table')
+
+    if IDS.TOP_REACTION_TIME_TABLE in selected_streams:
+        sync_metrics(atx, 'top_reaction_time_table')
+
+    if IDS.TOP_REPLIES_TABLE in selected_streams:
+        sync_metrics(atx, 'top_replies_table')
 
     # add additional analytics here

--- a/tap_frontapp/streams.py
+++ b/tap_frontapp/streams.py
@@ -149,6 +149,27 @@ def sync_metric(atx, metric, incremental_range, start_date, end_date):
                     "num_composed_p": row[8]['p']
                     })
 
+    # transform the team_table data
+    if metric == 'tags_table':
+        for row in data:
+            data_rows.append({
+                "analytics_date": start_date_formatted,
+                "analytics_range": incremental_range,
+                "tag_v": row[0]['v'],
+                "tag_url": row[0]['url'],
+                "tag_id": row[0]['id'],
+                "conversations_archived_v": row[1]['v'],
+                "conversations_archived_p": row[1]['p'],
+                "conversations_open_v": row[2]['v'],
+                "conversations_open_p": row[2]['p'],
+                "conversations_total_v": row[3]['v'],
+                "conversations_total_p": row[3]['p'],
+                "num_messages_v": row[4]['v'],
+                "num_messages_p": row[4]['p'],
+                "avg_message_conversations_v": row[5]['v'],
+                "avg_message_conversations_p": row[5]['p']
+                })
+
     write_records(metric, data_rows)
 
 def write_metrics_state(atx, metric, date_to_resume):
@@ -222,5 +243,8 @@ def sync_selected_streams(atx):
 
     if IDS.TEAM_TABLE in selected_streams:
         sync_metrics(atx, 'team_table')
+
+    if IDS.TAGS_TABLE in selected_streams:
+        sync_metrics(atx, 'tags_table')
 
     # add additional analytics here

--- a/tap_frontapp/streams.py
+++ b/tap_frontapp/streams.py
@@ -65,7 +65,7 @@ def select_fields(mdata, obj):
 @on_exception(constant, MetricsRateLimitException, max_tries=5, interval=60)
 @on_exception(expo, RateLimitException, max_tries=5)
 @sleep_and_retry
-@limits(calls=1ß, period=61) # 60 seconds needed to be padded by 1 second to work
+@limits(calls=1, period=61) # 60 seconds needed to be padded by 1 second to work
 def get_metric(atx, metric, start_date, end_date):
     LOGGER.info('Metrics query - metric: {} start_date: {} end_date: {} '.format(
         metric,


### PR DESCRIPTION
# Description of change
As per requested in issue #11  , this add a stream for the following analytics tables of frontapp:


Name | Resource type | Values
-- | -- | --
customers_table | List of customers | Number of messages, average first reply time, average response time and average resolution time
first_response_histo | List of duration | Percentage of first responses sent for each duration
resolution_histo | List of duration | Percentage of resolved conversation for each duration
response_histo | List of duration | Percentage of responses sent for each duration
tags_table | List of tags | Number of messages, average number of messages per conversation, number of archived conversations, number of open conversations, total number of conversations
top_conversations_table | Top 3 teammates | Number of conversations
top_reaction_time_table | Top 3 teammates | Time to react to a conversation
top_replies_table | Top 3 teammates | Number of replies sent


# Manual QA steps
 - Check that the tap is working properly in discovery and in sync mode with the `tags_table` stream selected.
 
# Risks
 - ?
 
# Rollback steps
 - revert this branch
