### PR TITLE
Add streams for all time graph analytics reports

### DIFF
--- a/tap_frontapp/http.py
+++ b/tap_frontapp/http.py
@@ -38,6 +38,10 @@ class Client(object):
             if 0 < wait <= 300:
                 time.sleep(wait)
 
+        if 'metricRowsKey' in kwargs:
+            metricRowsKey = kwargs['metricRowsKey']
+            del kwargs['metricRowsKey']
+
         if 'headers' not in kwargs:
             kwargs['headers'] = {}
         if self.token:
@@ -77,7 +81,7 @@ class Client(object):
             raise
 
         if len(response.json()['metrics']) > 0:
-            return response.json()['metrics'][0]['rows']
+            return response.json()['metrics'][0][metricRowsKey]
         else:
             return {}
 

--- a/tap_frontapp/schemas.py
+++ b/tap_frontapp/schemas.py
@@ -6,13 +6,34 @@ from singer import utils
 
 class IDS(object): # pylint: disable=too-few-public-methods
     TEAM_TABLE = 'team_table'
+    CUSTOMERS_HELPED_GRAPH = 'customers_helped_graph'
+    FIRST_RESPONSE_GRAPH = 'first_response_graph'
+    MESSAGES_RECEIVED_GRAPH = 'messages_received_graph'
+    NEW_CONVERSATIONS_GRAPH = 'new_conversations_graph'
+    REPLIES_SENT_GRAPH = 'replies_sent_graph'
+    RESOLUTION_GRAPH = 'resolution_graph'
+    RESPONSE_GRAPH = 'response_graph'
 
 STATIC_SCHEMA_STREAM_IDS = [
-    IDS.TEAM_TABLE
+    IDS.TEAM_TABLE,
+    IDS.CUSTOMERS_HELPED_GRAPH,
+    IDS.FIRST_RESPONSE_GRAPH,
+    IDS.MESSAGES_RECEIVED_GRAPH,
+    IDS.NEW_CONVERSATIONS_GRAPH,
+    IDS.REPLIES_SENT_GRAPH,
+    IDS.RESOLUTION_GRAPH,
+    IDS.RESPONSE_GRAPH
 ]
 
 PK_FIELDS = {
-    IDS.TEAM_TABLE: ['analytics_date', 'analytics_range', 'teammate_v']
+    IDS.TEAM_TABLE: ['analytics_date', 'analytics_range', 'teammate_v'],
+    IDS.CUSTOMERS_HELPED_GRAPH: ['analytics_date', 'analytics_range', 'start', 'end'],
+    IDS.FIRST_RESPONSE_GRAPH: ['analytics_date', 'analytics_range', 'start', 'end'],
+    IDS.MESSAGES_RECEIVED_GRAPH: ['analytics_date', 'analytics_range', 'start', 'end'],
+    IDS.NEW_CONVERSATIONS_GRAPH: ['analytics_date', 'analytics_range', 'start', 'end'],
+    IDS.REPLIES_SENT_GRAPH: ['analytics_date', 'analytics_range', 'start', 'end'],
+    IDS.RESOLUTION_GRAPH: ['analytics_date', 'analytics_range', 'start', 'end'],
+    IDS.RESPONSE_GRAPH: ['analytics_date', 'analytics_range', 'start', 'end']
 }
 
 def normalize_fieldname(fieldname):

--- a/tap_frontapp/schemas/customers_helped_graph.json
+++ b/tap_frontapp/schemas/customers_helped_graph.json
@@ -1,0 +1,52 @@
+{
+    "type": [
+        "null",
+        "object"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "analytics_date": {
+            "type": [
+                "null",
+                "string"
+            ],
+            "format": "date"
+        },
+        "analytics_range": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "start": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        },
+        "end": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        },
+        "label": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "p": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        },
+        "v": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        }
+    }
+}

--- a/tap_frontapp/schemas/first_response_graph.json
+++ b/tap_frontapp/schemas/first_response_graph.json
@@ -1,0 +1,52 @@
+{
+    "type": [
+        "null",
+        "object"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "analytics_date": {
+            "type": [
+                "null",
+                "string"
+            ],
+            "format": "date"
+        },
+        "analytics_range": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "start": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        },
+        "end": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        },
+        "label": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "p": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        },
+        "v": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        }
+    }
+}

--- a/tap_frontapp/schemas/messages_received_graph.json
+++ b/tap_frontapp/schemas/messages_received_graph.json
@@ -1,0 +1,52 @@
+{
+    "type": [
+        "null",
+        "object"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "analytics_date": {
+            "type": [
+                "null",
+                "string"
+            ],
+            "format": "date"
+        },
+        "analytics_range": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "start": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        },
+        "end": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        },
+        "label": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "p": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        },
+        "v": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        }
+    }
+}

--- a/tap_frontapp/schemas/new_conversations_graph.json
+++ b/tap_frontapp/schemas/new_conversations_graph.json
@@ -1,0 +1,52 @@
+{
+    "type": [
+        "null",
+        "object"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "analytics_date": {
+            "type": [
+                "null",
+                "string"
+            ],
+            "format": "date"
+        },
+        "analytics_range": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "start": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        },
+        "end": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        },
+        "label": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "p": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        },
+        "v": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        }
+    }
+}

--- a/tap_frontapp/schemas/replies_sent_graph.json
+++ b/tap_frontapp/schemas/replies_sent_graph.json
@@ -1,0 +1,52 @@
+{
+    "type": [
+        "null",
+        "object"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "analytics_date": {
+            "type": [
+                "null",
+                "string"
+            ],
+            "format": "date"
+        },
+        "analytics_range": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "start": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        },
+        "end": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        },
+        "label": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "p": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        },
+        "v": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        }
+    }
+}

--- a/tap_frontapp/schemas/resolution_graph.json
+++ b/tap_frontapp/schemas/resolution_graph.json
@@ -1,0 +1,52 @@
+{
+    "type": [
+        "null",
+        "object"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "analytics_date": {
+            "type": [
+                "null",
+                "string"
+            ],
+            "format": "date"
+        },
+        "analytics_range": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "start": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        },
+        "end": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        },
+        "label": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "p": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        },
+        "v": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        }
+    }
+}

--- a/tap_frontapp/schemas/response_graph.json
+++ b/tap_frontapp/schemas/response_graph.json
@@ -1,0 +1,52 @@
+{
+    "type": [
+        "null",
+        "object"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "analytics_date": {
+            "type": [
+                "null",
+                "string"
+            ],
+            "format": "date"
+        },
+        "analytics_range": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "start": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        },
+        "end": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        },
+        "label": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "p": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        },
+        "v": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
# Description of change
The frontapp analytics API expose a set of graph reports through its
/analytics API endpoints.

This adds streams for those.

Partially fix: #11 

# Manual QA steps
 - Run the tap
 
# Risks
 - ?
 
# Rollback steps
 - revert this branch
