### PR TITLE
Sets a User-Agent header on requests to Front API

### DIFF
--- a/tap_frontapp/http.py
+++ b/tap_frontapp/http.py
@@ -46,6 +46,7 @@ class Client(object):
             kwargs['headers']['Authorization'] = self.token
 
         kwargs['headers']['Content-Type'] = 'application/json'
+        kwargs['headers']['User-Agent'] = 'singer-io/tap-frontapp'
 
         if 'endpoint' in kwargs:
             endpoint = kwargs['endpoint']


### PR DESCRIPTION
# Description of change
Adds a `User-Agent` header to API requests sent to the Front API. 
This should allow the team at Front to more quickly identify use of this library, and provide more efficient support.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
