### PR TITLE
Feature/sac 27535 frontapp

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,8 @@ version: 2
 jobs:
   build:
     docker:
-      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester-v4
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester
+
     steps:
       - checkout
       - run:

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ tags
 singer-check-tap-data
 state.json
 catalog.json
+output.json
+convert_json_csv.py
+notes_frontapp.txt

--- a/example.config.json
+++ b/example.config.json
@@ -1,4 +1,0 @@
-{
-  "token": "<myapitoken>",
-  "start_date": "2018-01-01T00:00:00Z"
-}

--- a/setup.py
+++ b/setup.py
@@ -10,11 +10,11 @@ setup(
     url="http://singer.io",
     classifiers=["Programming Language :: Python :: 3 :: Only"],
     install_requires=[
-        "singer-python==5.4.0",
-        "pendulum",
-        "ratelimit",
-        "backoff==1.3.2",
-        "requests==2.31.0",
+        "singer-python==6.1.1",
+        "pendulum==3.1.0",
+        "ratelimit==2.2.1",
+        "backoff==2.2.1",
+        "requests==2.32.3",
     ],
     entry_points="""
     [console_scripts]

--- a/tap_frontapp/__init__.py
+++ b/tap_frontapp/__init__.py
@@ -23,24 +23,38 @@ LOGGER = singer.get_logger()
 #  call to the api but with the odd frontapp structure, we won't do that
 #  here we never use atx in here since the schema is from file but we
 #  would use it if we pulled schema from the API def discover(atx):
+
+
 def discover():
     catalog = Catalog([])
+    
+    # Build initial catalog from schema files
     for tap_stream_id in schemas.STATIC_SCHEMA_STREAM_IDS:
-        #print("tap stream id=",tap_stream_id)
+        LOGGER.info("tap stream id=%s", tap_stream_id)
         schema = Schema.from_dict(schemas.load_schema(tap_stream_id))
         metadata = []
+        
+        # Stream-level metadata select the stream
+        metadata.append({
+            "metadata": {
+                "selected": True  # Make sure to select every stream
+            },
+            "breadcrumb": []
+        })
+        
+        # Field level metadata with inclusion type
         for field_name in schema.properties.keys():
-            #print("field name=",field_name)
             if field_name in schemas.PK_FIELDS[tap_stream_id]:
                 inclusion = 'automatic'
             else:
                 inclusion = 'available'
             metadata.append({
-                'metadata': {
-                    'inclusion': inclusion
+                "metadata": {
+                    "inclusion": inclusion
                 },
-                'breadcrumb': ['properties', field_name]
+                "breadcrumb": ['properties', field_name]
             })
+        
         catalog.streams.append(CatalogEntry(
             stream=tap_stream_id,
             tap_stream_id=tap_stream_id,
@@ -48,7 +62,70 @@ def discover():
             schema=schema,
             metadata=metadata
         ))
-    return catalog
+    
+    # Creating a dict to change before converting
+    catalog_dict = catalog.to_dict()
+    
+    required_streams = [
+        "accounts_table",
+        "channels_table",
+        "inboxes_table",
+        "tags_table",
+        "teammates_table",
+        "teams_table"
+    ]
+    
+    # We verify this to ensure all mandatory streams are available even if schema files are missing
+    present_streams = {stream['tap_stream_id'] for stream in catalog_dict['streams']}
+    
+    # Ensure all required streams are included even if schema is missing
+    for stream_name in required_streams:
+        if stream_name not in present_streams:
+
+            LOGGER.info("Adding missing required stream: %s", stream_name)
+            
+            # Create a minimal stream entry that will be visible in the output
+            catalog_dict['streams'].append({
+                "stream": stream_name,
+                "tap_stream_id": stream_name,
+                "schema": {
+                    "type": ['null', 'object'],
+                    "properties": {},
+                    "additionalProperties": False
+                },
+                "key_properties": [],
+                "metadata": [
+                    {
+                        "metadata": {
+                            "selected": True
+                        },
+                        "breadcrumb": []
+                    }
+                ]
+            })
+    
+    # This ensure singer tools recognize all streams in the catalog dictionary
+    for stream in catalog_dict['streams']:
+        has_selection = False
+        for metadata_item in stream.get('metadata', []):
+            if metadata_item.get('breadcrumb') == [] and metadata_item.get('metadata', {}).get('selected') is True:
+                has_selection = True
+                break
+                
+        if not has_selection:
+            LOGGER.info("Adding selection metadata to stream: %s", stream['tap_stream_id'])
+            stream.setdefault('metadata', []).insert(0, {
+                "metadata": {
+                    "selected": True
+                },
+                "breadcrumb": []
+            })
+    
+    # Convert back to a Catalog object
+    modified_catalog = Catalog.from_dict(catalog_dict)
+
+    
+    return modified_catalog
 
 
 def get_abs_path(path: str):
@@ -56,7 +133,7 @@ def get_abs_path(path: str):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), path)
 
 
-# this is already defined in schemas.py though w/o dependencies.  do we keep this for the sync?
+# this is already defined in schemas.py though w/o dependencies
 def load_schema(tap_stream_id):
     path = "schemas/{}.json".format(tap_stream_id)
     schema = utils.load_json(get_abs_path(path))

--- a/tap_frontapp/__init__.py
+++ b/tap_frontapp/__init__.py
@@ -6,165 +6,45 @@ import json
 
 import singer
 from singer import utils
-from singer.catalog import Catalog, CatalogEntry, Schema
+from singer.catalog import Catalog
 from . import streams
 from .context import Context
+from .discover import discover
+from .sync import sync
 from . import schemas
 
 REQUIRED_CONFIG_KEYS = ["token"]
-
 LOGGER = singer.get_logger()
-
-#def check_authorization(atx):
-#    atx.client.get('/settings')
-
-
-# Some taps do discovery dynamically where the catalog is read in from a
-#  call to the api but with the odd frontapp structure, we won't do that
-#  here we never use atx in here since the schema is from file but we
-#  would use it if we pulled schema from the API def discover(atx):
-
-
-def discover():
-    catalog = Catalog([])
-    
-    # Build initial catalog from schema files
-    for tap_stream_id in schemas.STATIC_SCHEMA_STREAM_IDS:
-        LOGGER.info("tap stream id=%s", tap_stream_id)
-        schema = Schema.from_dict(schemas.load_schema(tap_stream_id))
-        metadata = []
-        
-        # Stream-level metadata select the stream
-        metadata.append({
-            "metadata": {
-                "selected": True  # Make sure to select every stream
-            },
-            "breadcrumb": []
-        })
-        
-        # Field level metadata with inclusion type
-        for field_name in schema.properties.keys():
-            if field_name in schemas.PK_FIELDS[tap_stream_id]:
-                inclusion = 'automatic'
-            else:
-                inclusion = 'available'
-            metadata.append({
-                "metadata": {
-                    "inclusion": inclusion
-                },
-                "breadcrumb": ['properties', field_name]
-            })
-        
-        catalog.streams.append(CatalogEntry(
-            stream=tap_stream_id,
-            tap_stream_id=tap_stream_id,
-            key_properties=schemas.PK_FIELDS[tap_stream_id],
-            schema=schema,
-            metadata=metadata
-        ))
-    
-    # Creating a dict to change before converting
-    catalog_dict = catalog.to_dict()
-    
-    required_streams = [
-        "accounts_table",
-        "channels_table",
-        "inboxes_table",
-        "tags_table",
-        "teammates_table",
-        "teams_table"
-    ]
-    
-    # We verify this to ensure all mandatory streams are available even if schema files are missing
-    present_streams = {stream['tap_stream_id'] for stream in catalog_dict['streams']}
-    
-    # Ensure all required streams are included even if schema is missing
-    for stream_name in required_streams:
-        if stream_name not in present_streams:
-
-            LOGGER.info("Adding missing required stream: %s", stream_name)
-            
-            # Create a minimal stream entry that will be visible in the output
-            catalog_dict['streams'].append({
-                "stream": stream_name,
-                "tap_stream_id": stream_name,
-                "schema": {
-                    "type": ['null', 'object'],
-                    "properties": {},
-                    "additionalProperties": False
-                },
-                "key_properties": [],
-                "metadata": [
-                    {
-                        "metadata": {
-                            "selected": True
-                        },
-                        "breadcrumb": []
-                    }
-                ]
-            })
-    
-    # This ensure singer tools recognize all streams in the catalog dictionary
-    for stream in catalog_dict['streams']:
-        has_selection = False
-        for metadata_item in stream.get('metadata', []):
-            if metadata_item.get('breadcrumb') == [] and metadata_item.get('metadata', {}).get('selected') is True:
-                has_selection = True
-                break
-                
-        if not has_selection:
-            LOGGER.info("Adding selection metadata to stream: %s", stream['tap_stream_id'])
-            stream.setdefault('metadata', []).insert(0, {
-                "metadata": {
-                    "selected": True
-                },
-                "breadcrumb": []
-            })
-    
-    # Convert back to a Catalog object
-    modified_catalog = Catalog.from_dict(catalog_dict)
-
-    
-    return modified_catalog
 
 
 def get_abs_path(path: str):
-    """Returns absolute path for URL."""
+    """Returns absolute path for a given relative path."""
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), path)
 
 
-# this is already defined in schemas.py though w/o dependencies
 def load_schema(tap_stream_id):
-    path = "schemas/{}.json".format(tap_stream_id)
+    """Loads schema from JSON file, resolving dependencies."""
+    path = f"schemas/{tap_stream_id}.json"
     schema = utils.load_json(get_abs_path(path))
     dependencies = schema.pop("tap_schema_dependencies", [])
-    refs = {}
-    for sub_stream_id in dependencies:
-        refs[sub_stream_id] = load_schema(sub_stream_id)
+    refs = {sub_id: load_schema(sub_id) for sub_id in dependencies}
     if refs:
         singer.resolve_schema_references(schema, refs)
     return schema
-
-
-def sync(atx):
-    for tap_stream_id in schemas.STATIC_SCHEMA_STREAM_IDS:
-        schemas.load_and_write_schema(tap_stream_id)
-
-    streams.sync_selected_streams(atx)
 
 
 @utils.handle_top_exception(LOGGER)
 def main():
     args = utils.parse_args(REQUIRED_CONFIG_KEYS)
     atx = Context(args.config, args.state)
+
     if args.discover:
-        # the schema is static from file so we don't need to pass in atx for connection info.
         catalog = discover()
         json.dump(catalog.to_dict(), sys.stdout)
     else:
-        atx.catalog = Catalog.from_dict(args.properties) \
-            if args.properties else discover()
+        atx.catalog = Catalog.from_dict(args.properties) if args.properties else discover()
         sync(atx)
+
 
 if __name__ == "__main__":
     main()

--- a/tap_frontapp/discover.py
+++ b/tap_frontapp/discover.py
@@ -1,0 +1,38 @@
+import singer
+from singer import metadata
+from singer.catalog import Catalog, CatalogEntry, Schema
+from .schemas import get_schemas
+
+LOGGER = singer.get_logger()
+
+
+def discover() -> Catalog:
+    """Run the discovery mode, prepare the catalog file and return the catalog."""
+    schemas, field_metadata = get_schemas()
+    print("Schemas loaded:", schemas.keys())
+
+    catalog = Catalog([])
+
+    for stream_name, schema_dict in schemas.items():
+        try:
+            schema = Schema.from_dict(schema_dict)
+            mdata = field_metadata[stream_name]
+        except Exception as err:
+            LOGGER.error(err)
+            LOGGER.error(f"stream_name: {stream_name}")
+            LOGGER.error(f"type schema_dict: {type(schema_dict)}")
+            raise err
+
+        key_properties = mdata.get((), {}).get("table-key-properties",[])
+
+        catalog.streams.append(
+            CatalogEntry(
+                stream=stream_name,
+                tap_stream_id=stream_name,
+                key_properties=key_properties,
+                schema=schema,
+                metadata=metadata.to_list(mdata),
+            )
+        )
+
+    return catalog

--- a/tap_frontapp/schemas.py
+++ b/tap_frontapp/schemas.py
@@ -1,18 +1,17 @@
 import os
 import re
-
 import singer
-from singer import utils
+from singer import metadata, utils
 
+LOGGER = singer.get_logger()
 
-class IDS(object):  # pylint: disable=too-few-public-methods
-    ACCOUNTS_TABLE = 'accounts_table'
-    CHANNELS_TABLE = 'channels_table'
-    INBOXES_TABLE = 'inboxes_table'
-    TAGS_TABLE = 'tags_table'
-    TEAMMATES_TABLE = 'teammates_table'
-    TEAMS_TABLE = 'teams_table'
-
+class IDS:  # pylint: disable=too-few-public-methods
+    ACCOUNTS_TABLE = "accounts_table"
+    CHANNELS_TABLE = "channels_table"
+    INBOXES_TABLE = "inboxes_table"
+    TAGS_TABLE = "tags_table"
+    TEAMMATES_TABLE = "teammates_table"
+    TEAMS_TABLE = "teams_table"
 
 STATIC_SCHEMA_STREAM_IDS = [
     IDS.ACCOUNTS_TABLE,
@@ -24,38 +23,59 @@ STATIC_SCHEMA_STREAM_IDS = [
 ]
 
 PK_FIELDS = {
-    IDS.ACCOUNTS_TABLE: ['analytics_date', 'analytics_range', 'report_id', 'metric_id'],
-    IDS.CHANNELS_TABLE: ['analytics_date', 'analytics_range', 'report_id', 'metric_id'],
-    IDS.INBOXES_TABLE: ['analytics_date', 'analytics_range', 'report_id', 'metric_id'],
-    IDS.TAGS_TABLE: ['analytics_date', 'analytics_range', 'report_id', 'metric_id'],
-    IDS.TEAMMATES_TABLE: ['analytics_date', 'analytics_range', 'report_id', 'metric_id'],
-    IDS.TEAMS_TABLE: ['analytics_date', 'analytics_range', 'report_id', 'metric_id'],
+    IDS.ACCOUNTS_TABLE: ["analytics_date", "analytics_range", "report_id", "metric_id"],
+    IDS.CHANNELS_TABLE: ["analytics_date", "analytics_range", "report_id", "metric_id"],
+    IDS.INBOXES_TABLE: ["analytics_date", "analytics_range", "report_id", "metric_id"],
+    IDS.TAGS_TABLE: ["analytics_date", "analytics_range", "report_id", "metric_id"],
+    IDS.TEAMMATES_TABLE: ["analytics_date", "analytics_range", "report_id", "metric_id"],
+    IDS.TEAMS_TABLE: ["analytics_date", "analytics_range", "report_id", "metric_id"],
 }
 
 
 def normalize_fieldname(fieldname):
     fieldname = fieldname.lower()
-    fieldname = re.sub(r'[\s\-]', '_', fieldname)
-    return re.sub(r'[^a-z0-9_]', '', fieldname)
+    fieldname = re.sub(r"[\s\-]", "_", fieldname)
+    return re.sub(r"[^a-z0-9_]", "", fieldname)
 
-
-# the problem with the schema we see coming from team_table is that it's a little inconsistent:
-# {"t":"str","v":"All","p":"All"},{"t":"num","v":306,"p":465},{"t":"num","v":2.65,"p":2.39},...
-# ,[{"t":"teammate","v":"Andrew","url":"/api/1/companies/theguild_co/team/andrew","id":253419},...
-# so we see that the type = teammate is different when it covers All team members
-# also we see the schema where type = num or dur is actually a triplet of type, value, and previous
-# so it looks like we need to hardcode those anomalies into this file
 
 def get_abs_path(path):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), path)
 
 
 def load_schema(tap_stream_id):
-    path = 'schemas/{}.json'.format(tap_stream_id)
-    # print("schema path=",path)
+    path = f"schemas/{tap_stream_id}.json"
     return utils.load_json(get_abs_path(path))
 
 
 def load_and_write_schema(tap_stream_id):
     schema = load_schema(tap_stream_id)
     singer.write_schema(tap_stream_id, schema, PK_FIELDS[tap_stream_id])
+
+
+def get_schemas():
+    """Loads all schemas and constructs metadata using Singer standards."""
+    schemas = {}
+    metadata_map = {}
+
+    for stream_id in STATIC_SCHEMA_STREAM_IDS:
+        raw_schema = load_schema(stream_id)
+        schema = utils.load_json(get_abs_path(f"schemas/{stream_id}.json"))
+        mdata = metadata.new()
+
+        # Stream-level metadata
+        mdata = metadata.write(mdata, (), "inclusion", "available")
+        mdata = metadata.write(mdata, (), "selected-by-default", True)
+        mdata = metadata.write(mdata, (), "inclusion-reason", "automatic")
+        mdata = metadata.write(mdata, (), "table-key-properties", PK_FIELDS[stream_id])
+
+        # Field-level metadata
+        for field_name in schema["properties"].keys():
+            inclusion = "automatic" if field_name in PK_FIELDS[stream_id] else "available"
+            mdata = metadata.write(mdata, ("properties", field_name), "inclusion", inclusion)
+            mdata = metadata.write(mdata, ("properties", field_name), "selected-by-default", True)
+            mdata = metadata.write(mdata, ("properties", field_name), "inclusion-reason", "manual")
+
+        schemas[stream_id] = schema
+        metadata_map[stream_id] = mdata
+
+    return schemas, metadata_map

--- a/tap_frontapp/sync.py
+++ b/tap_frontapp/sync.py
@@ -1,0 +1,34 @@
+import singer
+from typing import Dict
+from singer.catalog import Catalog
+from tap_frontapp.streams import sync_selected_streams
+from tap_frontapp.schemas import load_and_write_schema, STATIC_SCHEMA_STREAM_IDS
+
+LOGGER = singer.get_logger()
+
+
+def update_currently_syncing(state: Dict, stream_name: str) -> None:
+    """Update currently_syncing in the Singer state."""
+    if not stream_name and singer.get_currently_syncing(state):
+        del state["currently_syncing"]
+    else:
+        singer.set_currently_syncing(state, stream_name)
+    singer.write_state(state)
+
+
+def sync(client, config: Dict, catalog: Catalog, state: Dict) -> None:
+    """Main sync method to process selected streams."""
+    streams_to_sync = [s.tap_stream_id for s in catalog.get_selected_streams(state)]
+    LOGGER.info(f"Selected streams: {streams_to_sync}")
+
+    last_stream = singer.get_currently_syncing(state)
+    LOGGER.info(f"Last stream synced (if resuming): {last_stream}")
+
+    # Load and emit schemas for all static streams
+    for stream_name in STATIC_SCHEMA_STREAM_IDS:
+        load_and_write_schema(stream_name)
+
+    # Sync stream records
+    LOGGER.info("Starting sync of selected streams")
+    sync_selected_streams(client, streams_to_sync, catalog, state)
+    LOGGER.info("All selected streams synced successfully")

--- a/tests/unittests/test_client.py
+++ b/tests/unittests/test_client.py
@@ -1,0 +1,81 @@
+import unittest
+from unittest.mock import patch
+import requests
+from tap_frontapp.http import Client, RateLimitException, MetricsRateLimitException
+from requests.exceptions import Timeout, ConnectionError
+import json
+
+
+class MockResponse:
+    """Mock response object to simulate API calls."""
+    def __init__(self, status_code, headers=None, json_data=None, raise_for_status=False):
+        self.status_code = status_code
+        self.headers = headers or {}
+        self._json_data = json_data or {}
+        self._raise_for_status = raise_for_status
+        self.content = json.dumps(self._json_data)
+        self.text = json.dumps(self._json_data)
+
+    def json(self):
+        return self._json_data
+
+    def raise_for_status(self):
+        if self._raise_for_status:
+            raise requests.HTTPError("Mocker Error")
+        return self.status_code
+
+
+def get_mock_response(status_code=200, raise_for_status=False, json_data=None, headers=None):
+    return MockResponse(status_code, headers=headers, json_data=json_data, raise_for_status=raise_for_status)
+
+
+class TestFrontAppClient(unittest.TestCase):
+
+    @patch("requests.request")
+    def test_successful_request(self, mock_request):
+        mock_request.return_value = get_mock_response(
+            status_code=200,
+            headers={"X-Ratelimit-Remaining": "100", "X-Ratelimit-Reset": "1000"},
+            json_data={"metrics": [{"id": "m1"}]}
+        )
+        client = Client(config={"token": "test-token"})
+        response = client.get_report_metrics("https://api2.frontapp.com/analytics/reports/xyz")
+        self.assertEqual(response, [{"id": "m1"}])
+
+    @patch("requests.request")
+    def test_rate_limit_429(self, mock_request):
+        mock_request.return_value = get_mock_response(
+            status_code=429,
+            headers={"X-Ratelimit-Remaining": "0", "X-Ratelimit-Reset": "999"},
+            raise_for_status=True
+        )
+        client = Client(config={"token": "test-token"})
+        with self.assertRaises(RateLimitException):
+            client.get_report_metrics("https://api2.frontapp.com/analytics/reports/xyz")
+
+    @patch("requests.request")
+    def test_metrics_rate_limit_423(self, mock_request):
+        mock_request.return_value = get_mock_response(
+            status_code=423,
+            headers={"X-Ratelimit-Remaining": "10", "X-Ratelimit-Reset": "999"},
+            raise_for_status=True
+        )
+        client = Client(config={"token": "test-token"})
+        with self.assertRaises(MetricsRateLimitException):
+            client.get_report_metrics("https://api2.frontapp.com/analytics/reports/xyz")
+
+    @patch("requests.request", side_effect=Timeout)
+    def test_timeout_handling(self, mock_request):
+        client = Client(config={"token": "test-token"})
+        with self.assertRaises(Timeout):
+            client.get_report_metrics("https://api2.frontapp.com/analytics/reports/xyz")
+
+    @patch("requests.request", side_effect=ConnectionError)
+    def test_connection_error_handling(self, mock_request):
+        client = Client(config={"token": "test-token"})
+        with self.assertRaises(ConnectionError):
+            client.get_report_metrics("https://api2.frontapp.com/analytics/reports/xyz")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Description of change
Refactored the Tap FrontApp connector to modularize discovery and sync logic:
Moved discover() to a dedicated discover.py file for clarity and reuse.
Introduced sync.py to handle sync operations with better structure and logging.
Cleaned up and simplified __init__.py to delegate responsibilities to modular files.

# Manual QA steps
 Ran the discover mode
 
# Risks
 As of now NA.
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
