### PR TITLE
[SAC-27953] - Rate limit change for `get_report_metrics` API

### DIFF
--- a/tap_frontapp/streams.py
+++ b/tap_frontapp/streams.py
@@ -119,7 +119,7 @@ def select_fields(mdata, obj):
 @on_exception(constant, MetricsRateLimitException, max_tries=5, interval=60)
 @on_exception(expo, RateLimitException, max_tries=5)
 @sleep_and_retry
-@limits(calls=1, period=2)  # Reference: https://dev.frontapp.com/docs/rate-limiting
+@limits(calls=50, period=61)  # Reference: https://dev.frontapp.com/docs/rate-limiting
 def get_report_metrics(atx, report_url):
     return atx.client.get_report_metrics(report_url)
 


### PR DESCRIPTION
# Manual QA steps
- [x]  Discovery: running
- [x]  Sync: running
