### PR TITLE
Bump dependency versions for twistlock compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 2.0.2
-  * Bump dependency versions for twistlock compliance [#32](https://github.com/singer-io/tap-frontapp/pull/32)
+  * Bump dependency versions for twistlock compliance [#37](https://github.com/singer-io/tap-frontapp/pull/37)
 
 ## 2.0.1
   * Bump dependency versions for twistlock compliance [#31](https://github.com/singer-io/tap-frontapp/pull/31)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.0.2
+## 2.1.0
   * Bump dependency versions for twistlock compliance [#37](https://github.com/singer-io/tap-frontapp/pull/37)
 
 ## 2.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0.2
+  * Bump dependency versions for twistlock compliance [#32](https://github.com/singer-io/tap-frontapp/pull/32)
+
 ## 2.0.1
   * Bump dependency versions for twistlock compliance [#31](https://github.com/singer-io/tap-frontapp/pull/31)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="tap-frontapp",
-    version="2.0.2",
+    version="2.1.0",
     description="Singer.io tap for extracting data from the FrontApp API",
     author="bytcode.io",
     url="http://singer.io",

--- a/setup.py
+++ b/setup.py
@@ -4,17 +4,17 @@ from setuptools import setup, find_packages
 
 setup(
     name="tap-frontapp",
-    version="2.0.1",
+    version="2.0.2",
     description="Singer.io tap for extracting data from the FrontApp API",
     author="bytcode.io",
     url="http://singer.io",
     classifiers=["Programming Language :: Python :: 3 :: Only"],
     install_requires=[
-        "singer-python==6.1.1",
-        "pendulum==3.1.0",
+        "singer-python==6.4.0",
+        "pendulum==3.2.0",
         "ratelimit==2.2.1",
         "backoff==2.2.1",
-        "requests==2.32.4",
+        "requests==2.32.5",
     ],
     entry_points="""
     [console_scripts]


### PR DESCRIPTION
# Description of change
This PR updates dependency versions to address Twistlock compliance requirements, incrementing the package version from 2.0.1 to 2.0.2.

Changes:

- Bumped singer-python from 6.1.1 to 6.4.0
- Bumped pendulum from 3.1.0 to 3.2.0
- Bumped requests from 2.32.4 to 2.32.5
- Updated CHANGELOG.md to document the changes

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
