### PR TITLE
Bookmark Format Validation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,10 +10,11 @@ jobs:
       - run:
           name: 'Setup virtual env'
           command: |
-            uv venv --python 3.9 /usr/local/share/virtualenvs/tap-frontapp
+            uv venv --python 3.12 /usr/local/share/virtualenvs/tap-frontapp
             source /usr/local/share/virtualenvs/tap-frontapp/bin/activate
-            uv pip install -U 'pip==22.2.2' 'setuptools==65.3.0'
+            uv pip install -U setuptools
             uv pip install .[dev]
+      - add_ssh_keys
       - run:
           name: "JSON Validator"
           command: |
@@ -25,6 +26,14 @@ jobs:
             source /usr/local/share/virtualenvs/tap-frontapp/bin/activate
             uv pip install pylint
             pylint tap_frontapp -d C,R,W
+      - run:
+          name: "Unit Tests"
+          command: |
+            source /usr/local/share/virtualenvs/tap-frontapp/bin/activate
+            uv pip install pytest coverage parameterized
+            coverage run -m pytest tests/unittests
+            coverage html
+          when: always
 
 workflows:
   version: 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.2.0
+  * Upgraded dependencies versions and added unit tests [#38](https://github.com/singer-io/tap-frontapp/pull/38)
+
 ## 2.1.0
   * Bump dependency versions for twistlock compliance [#37](https://github.com/singer-io/tap-frontapp/pull/37)
 

--- a/setup.py
+++ b/setup.py
@@ -4,21 +4,21 @@ from setuptools import setup, find_packages
 
 setup(
     name="tap-frontapp",
-    version="2.1.0",
+    version="2.2.0",
     description="Singer.io tap for extracting data from the FrontApp API",
     author="bytcode.io",
     url="http://singer.io",
     classifiers=["Programming Language :: Python :: 3 :: Only"],
     install_requires=[
-        "singer-python==6.4.0",
+        "singer-python==6.7.0",
         "pendulum==3.2.0",
         "ratelimit==2.2.1",
         "backoff==2.2.1",
         "requests==2.32.5",
     ],
     entry_points="""
-    [console_scripts]
-    tap-frontapp=tap_frontapp:main
+        [console_scripts]
+        tap-frontapp=tap_frontapp:main
     """,
     packages=find_packages(),
     package_data = {

--- a/tap_frontapp/context.py
+++ b/tap_frontapp/context.py
@@ -45,15 +45,5 @@ class Context(object):
             val = val.isoformat()
         bks_.write_bookmark(self.state, path[0], path[1], val)
 
-    def get_offset(self, path):
-        off = bks_.get_offset(self.state, path[0])
-        return (off or {}).get(path[1])
-
-    def set_offset(self, path, val):
-        bks_.set_offset(self.state, path[0], path[1], val)
-
-    def clear_offsets(self, tap_stream_id):
-        bks_.clear_offset(self.state, tap_stream_id)
-
     def write_state(self):
         singer.write_state(self.state)

--- a/tap_frontapp/streams.py
+++ b/tap_frontapp/streams.py
@@ -154,7 +154,7 @@ def sync_metric(atx, metric_name, start_date, end_date):
 
         with singer.metrics.job_timer('daily_aggregated_metric'):
             start = time.monotonic()
-            start_date_formatted = datetime.datetime.utcfromtimestamp(start_date).strftime('%Y-%m-%d')
+            start_date_formatted = datetime.datetime.fromtimestamp(start_date, tz=datetime.timezone.utc).strftime('%Y-%m-%d')
             # we've really moved this functionality to the request in the http script
             # so we don't expect that this will actually have to run mult times
             while True:
@@ -201,7 +201,8 @@ def sync_metrics(atx, metric_name):
     #   set to the prior business day before we can use it.
     now = datetime.datetime.now()
     s_d = now.replace(hour=0, minute=0, second=0, microsecond=0)
-    start_date = pendulum.parse(atx.config.get('start_date', s_d + datetime.timedelta(days=-1, hours=0)))
+    default_start = (s_d + datetime.timedelta(days=-1, hours=0)).strftime("%Y-%m-%d %H:%M:%S")
+    start_date = pendulum.parse(atx.config.get('start_date', default_start))
     LOGGER.info('start_date: {} '.format(start_date))
 
     # end date is not usually specified in the config file by default so end_date is now.
@@ -235,5 +236,10 @@ def sync_metrics(atx, metric_name):
 
 
 def sync_selected_streams(atx):
+    from tap_frontapp.sync import update_currently_syncing
+
     for selected_stream in atx.selected_stream_ids:
+        update_currently_syncing(atx.state, selected_stream)
         sync_metrics(atx, selected_stream)
+
+    update_currently_syncing(atx.state, None)

--- a/tests/unittests/test_streams.py
+++ b/tests/unittests/test_streams.py
@@ -1,0 +1,306 @@
+import unittest
+from unittest.mock import MagicMock, patch, call
+import requests
+import pendulum
+from tap_frontapp.streams import (
+    write_metrics_state,
+    sync_metrics,
+    sync_selected_streams,
+    create_report,
+    get_report_metrics
+)
+
+
+class TestWriteMetricsState(unittest.TestCase):
+    """Test write_metrics_state function"""
+
+    def test_write_metrics_state_success(self):
+        """Test that write_metrics_state correctly writes bookmark"""
+        mock_atx = MagicMock()
+        mock_atx.state = {}
+
+        date_to_resume = pendulum.parse('2024-01-15T00:00:00Z')
+        write_metrics_state(mock_atx, 'test_metric', date_to_resume)
+
+        # Verify bookmark was written
+        self.assertIn('bookmarks', mock_atx.state)
+        self.assertIn('test_metric', mock_atx.state['bookmarks'])
+        self.assertEqual(
+            mock_atx.state['bookmarks']['test_metric']['date_to_resume'],
+            '2024-01-15 00:00:00'
+        )
+
+        # Verify write_state was called
+        mock_atx.write_state.assert_called_once()
+
+
+class TestSyncMetrics(unittest.TestCase):
+    """Test sync_metrics function"""
+
+    @patch('tap_frontapp.streams.sync_metric')
+    @patch('tap_frontapp.streams.write_metrics_state')
+    def test_sync_metrics_with_bookmark(self, mock_write_state, mock_sync_metric):
+        """Test sync_metrics when bookmark exists"""
+        mock_atx = MagicMock()
+        mock_atx.config = {
+            'start_date': '2024-01-01T00:00:00Z',
+            'end_date': '2024-01-03T00:00:00Z'
+        }
+        mock_atx.state = {
+            'bookmarks': {
+                'test_metric': {
+                    'date_to_resume': '2024-01-02 00:00:00'
+                }
+            }
+        }
+
+        sync_metrics(mock_atx, 'test_metric')
+        # Should sync from last bookmark (2024-01-02) to end date (2024-01-03)
+        self.assertEqual(mock_sync_metric.call_count, 2)
+
+    @patch('tap_frontapp.streams.sync_metric')
+    @patch('tap_frontapp.streams.write_metrics_state')
+    def test_sync_metrics_without_bookmark(self, mock_write_state, mock_sync_metric):
+        """Test sync_metrics when no bookmark exists"""
+        mock_atx = MagicMock()
+        mock_atx.config = {
+            'start_date': '2024-01-01T00:00:00Z',
+            'end_date': '2024-01-02T00:00:00Z'
+        }
+        mock_atx.state = {'bookmarks': {}}
+        sync_metrics(mock_atx, 'test_metric')
+
+        # Should sync from start_date
+        self.assertGreater(mock_sync_metric.call_count, 0)
+
+    @patch('tap_frontapp.streams.sync_metric')
+    @patch('tap_frontapp.streams.write_metrics_state')
+    def test_sync_metrics_writes_bookmark_after_each_day(self, mock_write_state, mock_sync_metric):
+        """Test that bookmark is written after each day sync"""
+        mock_atx = MagicMock()
+        mock_atx.config = {
+            'start_date': '2024-01-01T00:00:00Z',
+            'end_date': '2024-01-03T00:00:00Z'
+        }
+        mock_atx.state = {'bookmarks': {}}
+
+        sync_metrics(mock_atx, 'test_metric')
+        self.assertEqual(mock_write_state.call_count, mock_sync_metric.call_count)
+
+
+class TestSyncSelectedStreams(unittest.TestCase):
+    """Test sync_selected_streams function"""
+
+    @patch('tap_frontapp.sync.update_currently_syncing')
+    @patch('tap_frontapp.streams.sync_metrics')
+    def test_sync_selected_streams_updates_currently_syncing(self, mock_sync_metrics, mock_update):
+        """Test that currently_syncing is updated for each stream"""
+        mock_atx = MagicMock()
+        mock_atx.selected_stream_ids = ['stream1', 'stream2', 'stream3']
+        mock_atx.state = {}
+
+        sync_selected_streams(mock_atx)
+        calls = [
+            call(mock_atx.state, 'stream1'),
+            call(mock_atx.state, 'stream2'),
+            call(mock_atx.state, 'stream3'),
+            call(mock_atx.state, None)
+        ]
+        mock_update.assert_has_calls(calls)
+
+    @patch('tap_frontapp.sync.update_currently_syncing')
+    @patch('tap_frontapp.streams.sync_metrics')
+    def test_sync_selected_streams_syncs_all_streams(self, mock_sync_metrics, mock_update):
+        """Test that all selected streams are synced"""
+        mock_atx = MagicMock()
+        mock_atx.selected_stream_ids = ['accounts_table', 'teams_table']
+        mock_atx.state = {}
+        sync_selected_streams(mock_atx)
+
+        calls = [
+            call(mock_atx, 'accounts_table'),
+            call(mock_atx, 'teams_table')
+        ]
+        mock_sync_metrics.assert_has_calls(calls)
+        self.assertEqual(mock_sync_metrics.call_count, 2)
+
+
+class TestCreateReport(unittest.TestCase):
+    """Test create_report function"""
+
+    def test_create_report_success(self):
+        """Test successful report creation"""
+        mock_atx = MagicMock()
+        mock_atx.client.create_report.return_value = 'https://api2.frontapp.com/analytics/reports/xyz'
+        result = create_report(mock_atx, 1704067200, 1704153600, {'team_ids': ['team1']})
+        self.assertEqual(result, 'https://api2.frontapp.com/analytics/reports/xyz')
+        mock_atx.client.create_report.assert_called_once()
+
+    def test_create_report_bad_request_returns_none(self):
+        """Test that bad request returns None"""
+        mock_atx = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 400
+        mock_error = requests.exceptions.HTTPError()
+        mock_error.response = mock_response
+        mock_atx.client.create_report.side_effect = mock_error
+
+        result = create_report(mock_atx, 1704067200, 1704153600, {'team_ids': ['team1']})
+        self.assertIsNone(result)
+
+
+class TestHelperFunctions(unittest.TestCase):
+    """Test helper functions"""
+
+    @patch('singer.write_records')
+    @patch('singer.metrics.record_counter')
+    def test_write_records(self, mock_counter, mock_singer_write):
+        """Test write_records function"""
+        from tap_frontapp.streams import write_records
+        mock_counter_instance = MagicMock()
+        mock_counter.return_value.__enter__.return_value = mock_counter_instance
+        records = [{'id': 1}, {'id': 2}, {'id': 3}]
+        write_records('test_stream', records)
+        mock_singer_write.assert_called_once_with('test_stream', records)
+        mock_counter_instance.increment.assert_called_once_with(3)
+
+    def test_get_date_and_integer_fields(self):
+        """Test get_date_and_integer_fields function"""
+        from tap_frontapp.streams import get_date_and_integer_fields
+        mock_stream = MagicMock()
+        mock_stream.schema.properties = {
+            'id': MagicMock(type='integer', format=None),
+            'count': MagicMock(type=['null', 'integer'], format=None),
+            'created_at': MagicMock(type='string', format='date-time'),
+            'name': MagicMock(type='string', format=None),
+            'updated_at': MagicMock(type='string', format='date-time')
+        }
+        date_fields, integer_fields = get_date_and_integer_fields(mock_stream)
+        self.assertIn('created_at', date_fields)
+        self.assertIn('updated_at', date_fields)
+        self.assertIn('id', integer_fields)
+        self.assertIn('count', integer_fields)
+        self.assertNotIn('name', date_fields)
+        self.assertNotIn('name', integer_fields)
+
+    def test_base_transform_empty_string_to_none(self):
+        """Test base_transform converts empty strings to None"""
+        from tap_frontapp.streams import base_transform
+        obj = {
+            'id': '123',
+            'name': '',
+            'description': 'test'
+        }
+        result = base_transform([], [], obj)
+        self.assertIsNone(result['name'])
+        self.assertEqual(result['description'], 'test')
+
+    def test_base_transform_integer_conversion(self):
+        """Test base_transform converts integer fields"""
+        from tap_frontapp.streams import base_transform
+        obj = {
+            'id': '123',
+            'count': '456',
+            'total': '0'
+        }
+
+        integer_fields = ['id', 'count', 'total']
+        result = base_transform([], integer_fields, obj)
+        self.assertEqual(result['id'], 123)
+        self.assertEqual(result['count'], 456)
+        self.assertEqual(result['total'], 0)
+        self.assertIsInstance(result['id'], int)
+
+    @patch('pendulum.parse')
+    def test_base_transform_date_conversion(self, mock_parse):
+        """Test base_transform converts date fields"""
+        from tap_frontapp.streams import base_transform
+        mock_date = MagicMock()
+        mock_date.isoformat.return_value = '2024-01-01T00:00:00Z'
+        mock_parse.return_value = mock_date
+        obj = {
+            'created_at': '2024-01-01 00:00:00',
+            'name': 'test'
+        }
+        date_fields = ['created_at']
+        result = base_transform(date_fields, [], obj)
+        self.assertEqual(result['created_at'], '2024-01-01T00:00:00Z')
+        mock_parse.assert_called_once_with('2024-01-01 00:00:00')
+
+    def test_base_transform_handles_none_values(self):
+        """Test base_transform preserves None values"""
+        from tap_frontapp.streams import base_transform
+
+        obj = {
+            'id': None,
+            'count': None,
+            'created_at': None
+        }
+
+        result = base_transform(['created_at'], ['id', 'count'], obj)
+        self.assertIsNone(result['id'])
+        self.assertIsNone(result['count'])
+        self.assertIsNone(result['created_at'])
+
+
+class TestGetReportMetrics(unittest.TestCase):
+    """Test get_report_metrics function"""
+
+    def test_get_report_metrics_success(self):
+        """Test successful retrieval of report metrics"""
+        mock_atx = MagicMock()
+        mock_atx.client.get_report_metrics.return_value = [
+            {'id': 'metric1', 'value': 100},
+            {'id': 'metric2', 'value': 200}
+        ]
+        result = get_report_metrics(mock_atx, 'https://api.frontapp.com/reports/123')
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]['id'], 'metric1')
+        self.assertEqual(result[0]['value'], 100)
+
+
+class TestSyncMetric(unittest.TestCase):
+    """Test sync_metric function"""
+
+    @patch('tap_frontapp.streams.write_records')
+    @patch('tap_frontapp.streams.get_report_metrics')
+    @patch('tap_frontapp.streams.create_report')
+    def test_sync_metric_writes_records(self, mock_create_report,
+                                       mock_get_metrics, mock_write_records):
+        """Test sync_metric writes records"""
+        from tap_frontapp.streams import sync_metric
+        mock_atx = MagicMock()
+        mock_atx.client.list_metrics.return_value = [
+            {'id': 'team_123', 'name': 'Team A'}
+        ]
+        mock_create_report.return_value = 'https://api.frontapp.com/reports/123'
+        mock_get_metrics.return_value = [
+            {'id': 'avg_first_response_time', 'value': 3600},
+            {'id': 'avg_response_time', 'value': 7200}
+        ]
+        sync_metric(mock_atx, 'teams_table', 1609459200, 1609545600)
+        # Verify write_records was called
+        mock_write_records.assert_called_once()
+        # Verify the record structure
+        call_args = mock_write_records.call_args
+        stream_name = call_args[0][0]
+        records = call_args[0][1]
+        self.assertEqual(stream_name, 'teams_table')
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]['metric_id'], 'team_123')
+        self.assertEqual(records[0]['metric_description'], 'Team A')
+        self.assertEqual(records[0]['avg_first_response_time'], 3600)
+
+    @patch('tap_frontapp.streams.write_records')
+    @patch('tap_frontapp.streams.create_report')
+    def test_sync_metric_skips_when_no_report_url(self, mock_create_report,
+                                                   mock_write_records):
+        """Test sync_metric skips when create_report returns None"""
+        from tap_frontapp.streams import sync_metric
+        mock_atx = MagicMock()
+        mock_atx.client.list_metrics.return_value = [
+            {'id': 'team_123', 'name': 'Team A'}
+        ]
+        mock_create_report.return_value = None
+        sync_metric(mock_atx, 'teams_table', 1609459200, 1609545600)
+        mock_write_records.assert_not_called()

--- a/tests/unittests/test_sync.py
+++ b/tests/unittests/test_sync.py
@@ -1,0 +1,312 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from tap_frontapp.sync import update_currently_syncing, sync
+
+
+class TestUpdateCurrentlySyncing(unittest.TestCase):
+    """Test update_currently_syncing function"""
+
+    def test_set_currently_syncing(self):
+        """Test setting currently_syncing stream"""
+        state = {}
+        update_currently_syncing(state, 'test_stream')
+        self.assertEqual(state['currently_syncing'], 'test_stream')
+
+    def test_clear_currently_syncing(self):
+        """Test clearing currently_syncing"""
+        state = {'currently_syncing': 'test_stream'}
+        update_currently_syncing(state, None)
+        self.assertNotIn('currently_syncing', state)
+
+    def test_update_currently_syncing_writes_state(self):
+        """Test that state is written after update"""
+        state = {}
+        with patch('singer.write_state') as mock_write:
+            update_currently_syncing(state, 'test_stream')
+            mock_write.assert_called_once()
+
+
+class TestBookmarkValidation(unittest.TestCase):
+    """Test bookmark validation to ensure compliance with target-qlik requirements"""
+
+    def test_no_empty_offset_in_bookmarks(self):
+        """Test that bookmarks do not contain empty offset dictionaries"""
+        # Good state - no offset key
+        good_state = {
+            'bookmarks': {
+                'stream1': {
+                    'date_to_resume': '2024-01-01T00:00:00Z'
+                },
+                'stream2': {}  # Non-resumable stream with empty bookmark
+            }
+        }
+
+        # Validate no offset keys exist
+        for stream_name, bookmark in good_state.get('bookmarks', {}).items():
+            self.assertNotIn('offset', bookmark,
+                f"Stream '{stream_name}' should not have 'offset' key in bookmark")
+
+    def test_bookmark_structure_compliance(self):
+        """Test bookmark structure complies with target-qlik requirements"""
+        state = {
+            'bookmarks': {
+                'accounts_table': {
+                    'date_to_resume': '2024-01-15T00:00:00Z'
+                },
+                'teams_table': {
+                    'date_to_resume': '2024-01-10T00:00:00Z'
+                }
+            }
+        }
+
+        self.assertIn('bookmarks', state)
+        for stream_name, bookmark_data in state['bookmarks'].items():
+            # Verify it's a dictionary
+            self.assertIsInstance(bookmark_data, dict)
+            # Verify no offset key
+            self.assertNotIn('offset', bookmark_data,
+                f"Stream '{stream_name}' contains 'offset' key which violates target-qlik requirements")
+            # If bookmark has data, it should be resumable
+            if bookmark_data:
+                self.assertIn('date_to_resume', bookmark_data,
+                    f"Resumable stream '{stream_name}' should have 'date_to_resume' key")
+
+    def test_non_resumable_streams_have_empty_bookmarks(self):
+        """Test that non-resumable streams have empty bookmark dictionaries"""
+        state = {
+            'bookmarks': {
+                'resumable_stream': {
+                    'date_to_resume': '2024-01-01T00:00:00Z'
+                },
+                'non_resumable_stream': {}
+            }
+        }
+
+        # Non-resumable streams should have empty dict
+        self.assertEqual(state['bookmarks']['non_resumable_stream'], {})
+
+        # Should not have nested values (including offset)
+        non_resumable_bookmark = state['bookmarks']['non_resumable_stream']
+        self.assertEqual(len(non_resumable_bookmark), 0,
+            "Non-resumable stream should have completely empty bookmark dictionary")
+
+    def test_state_does_not_use_reserved_keys(self):
+        """Test that state doesn't use target_state or target_total_batches"""
+        state = {
+            'bookmarks': {
+                'stream1': {'date_to_resume': '2024-01-01T00:00:00Z'}
+            },
+            'currently_syncing': 'stream1'
+        }
+
+        # Reserved keys should not be present
+        self.assertNotIn('target_state', state,
+            "'target_state' is a reserved key and should not be used by taps")
+        self.assertNotIn('target_total_batches', state,
+            "'target_total_batches' is a reserved key and should not be used by taps")
+
+    def test_bookmark_value_existence_indicates_resumability(self):
+        """Test that existence of value under bookmarks.stream_id indicates resumability"""
+        state = {
+            'bookmarks': {
+                'resumable_stream': {
+                    'date_to_resume': '2024-01-01T00:00:00Z'
+                },
+                'another_resumable': {
+                    'date_to_resume': '2024-01-15T00:00:00Z'
+                },
+                'non_resumable': {}
+            }
+        }
+        # Check resumable streams
+        resumable_bookmark = state['bookmarks']['resumable_stream']
+        self.assertTrue(bool(resumable_bookmark),
+            "Resumable stream should have non-empty bookmark")
+        another_resumable_bookmark = state['bookmarks']['another_resumable']
+        self.assertTrue(bool(another_resumable_bookmark),
+            "Resumable stream should have non-empty bookmark")
+        non_resumable_bookmark = state['bookmarks']['non_resumable']
+        self.assertFalse(bool(non_resumable_bookmark),
+            "Non-resumable stream should have empty bookmark")
+
+
+class TestSyncFunction(unittest.TestCase):
+    """Test sync function"""
+
+    @patch('tap_frontapp.sync.sync_selected_streams')
+    @patch('tap_frontapp.sync.load_and_write_schema')
+    def test_sync_processes_selected_streams(self, mock_load_schema, mock_sync_streams):
+        """Test that sync processes all selected streams"""
+        mock_atx = MagicMock()
+        mock_atx.catalog.get_selected_streams.return_value = [
+            MagicMock(tap_stream_id='stream1'),
+            MagicMock(tap_stream_id='stream2')
+        ]
+        mock_atx.state = {}
+        sync(mock_atx)
+
+        # Verify sync_selected_streams was called
+        mock_sync_streams.assert_called_once_with(mock_atx)
+
+
+class TestInterruptedSync(unittest.TestCase):
+    """Test sync interruption and resumption scenarios"""
+
+    def test_currently_syncing_persists_on_interruption(self):
+        """Test that currently_syncing is preserved when sync is interrupted"""
+        state = {
+            'bookmarks': {
+                'stream1': {'date_to_resume': '2024-01-01T00:00:00Z'},
+                'stream2': {'date_to_resume': '2024-01-01T00:00:00Z'},
+                'stream3': {'date_to_resume': '2024-01-01T00:00:00Z'}
+            },
+            'currently_syncing': 'stream2'
+        }
+        # Verify currently_syncing is set
+        self.assertEqual(state['currently_syncing'], 'stream2')
+        # Verify bookmarks are preserved
+        self.assertIn('stream1', state['bookmarks'])
+        self.assertIn('stream2', state['bookmarks'])
+        self.assertIn('stream3', state['bookmarks'])
+
+    @patch('tap_frontapp.sync.sync_selected_streams')
+    @patch('tap_frontapp.sync.load_and_write_schema')
+    def test_sync_resumes_from_currently_syncing_stream(self, mock_load_schema, mock_sync_streams):
+        """Test that sync resumes from the currently_syncing stream"""
+        mock_atx = MagicMock()
+
+        # Simulate interrupted state
+        mock_atx.state = {
+            'bookmarks': {
+                'stream1': {'date_to_resume': '2024-01-15T00:00:00Z'},
+                'stream2': {'date_to_resume': '2024-01-01T00:00:00Z'},
+                'stream3': {}
+            },
+            'currently_syncing': 'stream2'
+        }
+
+        mock_atx.catalog.get_selected_streams.return_value = [
+            MagicMock(tap_stream_id='stream1'),
+            MagicMock(tap_stream_id='stream2'),
+            MagicMock(tap_stream_id='stream3')
+        ]
+
+        sync(mock_atx)
+
+        # Verify sync was called with state containing currently_syncing
+        mock_sync_streams.assert_called_once_with(mock_atx)
+        self.assertEqual(mock_atx.state['currently_syncing'], 'stream2')
+
+    def test_interrupted_stream_bookmark_updated(self):
+        """Test that interrupted stream's bookmark gets updated on partial completion"""
+        state = {
+            'bookmarks': {
+                'stream1': {'date_to_resume': '2024-01-15T00:00:00Z'},  # Completed
+                'stream2': {'date_to_resume': '2024-01-10T00:00:00Z'},  # Partially synced
+                'stream3': {}  # Not started
+            },
+            'currently_syncing': 'stream2'
+        }
+
+        # Verify the interrupted stream has a bookmark (partial progress saved)
+        self.assertIn('date_to_resume', state['bookmarks']['stream2'])
+
+        # Verify it's different from initial state (progress was made)
+        self.assertIsNotNone(state['bookmarks']['stream2']['date_to_resume'])
+
+    def test_state_cleared_after_successful_sync(self):
+        """Test that currently_syncing is cleared after all streams complete"""
+        state = {
+            'bookmarks': {
+                'stream1': {'date_to_resume': '2024-01-15T00:00:00Z'},
+                'stream2': {'date_to_resume': '2024-01-14T00:00:00Z'}
+            }
+        }
+
+        # After successful completion, currently_syncing should not be present
+        self.assertNotIn('currently_syncing', state)
+
+    @patch('singer.write_state')
+    def test_state_written_on_stream_transition(self, mock_write_state):
+        """Test that state is written when transitioning between streams"""
+        state = {}
+
+        # Simulate setting currently_syncing for first stream
+        update_currently_syncing(state, 'stream1')
+        self.assertEqual(mock_write_state.call_count, 1)
+
+        # Simulate transitioning to next stream
+        update_currently_syncing(state, 'stream2')
+        self.assertEqual(mock_write_state.call_count, 2)
+
+        # Simulate completion
+        update_currently_syncing(state, None)
+        self.assertEqual(mock_write_state.call_count, 3)
+
+    def test_interrupt_before_first_stream_starts(self):
+        """Test interruption before any stream has started"""
+        state = {
+            'bookmarks': {
+                'stream1': {},
+                'stream2': {},
+                'stream3': {}
+            }
+        }
+
+        # No currently_syncing means sync hasn't started or just started
+        self.assertNotIn('currently_syncing', state)
+
+        # All bookmarks are empty (no progress)
+        for bookmark in state['bookmarks'].values():
+            self.assertEqual(bookmark, {})
+
+    def test_interrupt_during_last_stream(self):
+        """Test interruption during the last stream"""
+        state = {
+            'bookmarks': {
+                'stream1': {'date_to_resume': '2024-01-15T00:00:00Z'},
+                'stream2': {'date_to_resume': '2024-01-14T00:00:00Z'},
+                'stream3': {'date_to_resume': '2024-01-10T00:00:00Z'}
+            },
+            'currently_syncing': 'stream3'
+        }
+
+        # Verify we're on the last stream
+        self.assertEqual(state['currently_syncing'], 'stream3')
+
+        # Verify previous streams completed (have bookmarks)
+        self.assertIsNotNone(state['bookmarks']['stream1']['date_to_resume'])
+        self.assertIsNotNone(state['bookmarks']['stream2']['date_to_resume'])
+
+    def test_multiple_interruptions_same_stream(self):
+        """Test multiple interruptions on the same stream with bookmark updates"""
+        # First interruption
+        state_v1 = {
+            'bookmarks': {
+                'stream1': {'date_to_resume': '2024-01-01T00:00:00Z'}
+            },
+            'currently_syncing': 'stream1'
+        }
+
+        # Second interruption - bookmark advanced
+        state_v2 = {
+            'bookmarks': {
+                'stream1': {'date_to_resume': '2024-01-05T00:00:00Z'}
+            },
+            'currently_syncing': 'stream1'
+        }
+
+        # Third interruption - bookmark advanced further
+        state_v3 = {
+            'bookmarks': {
+                'stream1': {'date_to_resume': '2024-01-10T00:00:00Z'}
+            },
+            'currently_syncing': 'stream1'
+        }
+
+        date1 = state_v1['bookmarks']['stream1']['date_to_resume']
+        date2 = state_v2['bookmarks']['stream1']['date_to_resume']
+        date3 = state_v3['bookmarks']['stream1']['date_to_resume']
+
+        self.assertLess(date1, date2)
+        self.assertLess(date2, date3)


### PR DESCRIPTION
# Description of change
[SAC-30238](https://qlik-dev.atlassian.net/browse/SAC-30238)
PR include validation for bookmark values, upgraded singer-python version and offset key removal(if present).
We have also updated datetime function `utcfromtimestamp` to `fromtimestamp` for `start_date_formatted ` in streams, because `utcfromtimestamp` is depreciated in python version 3.12.

# Manual QA steps
 - [x]  Discovery: Running
 - [x]  Sync: Running
 - [x]  Unit Tests: Running
 - [ ]  Integration test: Not Implemented
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
