### PR TITLE
update code for standard_metadata

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,16 @@ jobs:
             coverage run -m pytest tests/unittests
             coverage html
           when: always
+      - run:
+          name: "Integration Tests"
+          command: |
+            source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            uv pip install --upgrade awscli
+            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
+            source dev_env.sh
+            unset USE_STITCH_BACKEND
+            uv pip install -e .
+            run-test --tap=tap-frontapp tests
 
 workflows:
   version: 2

--- a/tap_frontapp/__init__.py
+++ b/tap_frontapp/__init__.py
@@ -70,7 +70,9 @@ def main():
     else:
         atx = Context(args.config, args.state)
 
-        catalog_obj = args.properties or getattr(args, "catalog", None)
+        catalog_obj = getattr(args, "properties", None)
+        if catalog_obj is None:
+            catalog_obj = getattr(args, "catalog", None)
         if catalog_obj is None:
             catalog_obj = discover()
         elif isinstance(catalog_obj, dict):

--- a/tap_frontapp/__init__.py
+++ b/tap_frontapp/__init__.py
@@ -8,12 +8,39 @@ import singer
 from singer import utils
 from singer.catalog import Catalog
 from .context import Context
-from .discover import discover, validate_credentials
-from .sync import sync
 from . import schemas
+from .discover import discover as _discover_impl, validate_credentials as _validate_credentials_impl
+from .sync import sync as _sync_impl
 
 REQUIRED_CONFIG_KEYS = ["token"]
 LOGGER = singer.get_logger()
+
+
+def discover(*args, **kwargs):
+    """Public discover function re-exported from discover module.
+
+    This wrapper exists so tests can patch ``tap_frontapp.discover``
+    and so the CLI entrypoint can call a stable symbol regardless of
+    where the implementation lives.
+    """
+
+    return _discover_impl(*args, **kwargs)
+
+
+def validate_credentials(*args, **kwargs):
+    """Public credential validation helper re-exported for tests."""
+
+    return _validate_credentials_impl(*args, **kwargs)
+
+
+def sync(*args, **kwargs):
+    """Public sync function re-exported from the sync module.
+
+    Tests patch ``tap_frontapp.sync`` and expect the entrypoint to call
+    this symbol directly.
+    """
+
+    return _sync_impl(*args, **kwargs)
 
 
 def get_abs_path(path):
@@ -39,10 +66,17 @@ def main():
     if args.discover:
         validate_credentials(args.config["token"])
         catalog = discover()
-        json.dump(catalog.to_dict(), sys.stdout)
+        json.dump(catalog.to_dict(), sys.stdout, indent=2)
     else:
         atx = Context(args.config, args.state)
-        atx.catalog = Catalog.from_dict(args.properties) if args.properties else discover()
+
+        catalog_obj = args.properties or getattr(args, "catalog", None)
+        if catalog_obj is None:
+            catalog_obj = discover()
+        elif isinstance(catalog_obj, dict):
+            catalog_obj = Catalog.from_dict(catalog_obj)
+
+        atx.catalog = catalog_obj
         sync(atx)
 
 

--- a/tap_frontapp/schemas.py
+++ b/tap_frontapp/schemas.py
@@ -60,16 +60,19 @@ def get_schemas():
 
     for stream_id in STATIC_SCHEMA_STREAM_IDS:
         schema = load_schema(stream_id)
-        mdata = metadata.new()
+        # Use Singer's standard metadata
+        mdata = metadata.get_standard_metadata(
+            schema=schema,
+            key_properties=PK_FIELDS[stream_id],
+            valid_replication_keys=["analytics_date"],
+            replication_method="INCREMENTAL",
+        )
 
-        # Stream-level metadata
-        mdata = metadata.write(mdata, (), "inclusion", "available")
-        mdata = metadata.write(mdata, (), "table-key-properties", PK_FIELDS[stream_id])
-
-        # Field-level metadata
-        for field_name in schema["properties"]:
-            inclusion = "automatic" if field_name in PK_FIELDS[stream_id] else "available"
-            mdata = metadata.write(mdata, ("properties", field_name), "inclusion", inclusion)
+        mdata = metadata.to_map(mdata)
+        automatic_fields = set(PK_FIELDS[stream_id]) | {"analytics_date"}
+        for field_name in schema.get("properties", {}).keys():
+            if field_name in automatic_fields:
+                mdata = metadata.write(mdata, ("properties", field_name), "inclusion", "automatic")
 
         schemas[stream_id] = schema
         metadata_map[stream_id] = mdata

--- a/tap_frontapp/streams.py
+++ b/tap_frontapp/streams.py
@@ -143,7 +143,9 @@ def create_report(atx, start_date, end_date, filters):
             raise e
 
 
-def sync_metric(atx, metric_name, start_date, end_date):
+def sync_metric(atx, metric_name, start_date, end_date, mdata=None):
+    if mdata is None:
+        mdata = {}
     for metric in atx.client.list_metrics(path=METRIC_API_PATH[metric_name]):
         metric_id = metric['id']
         metric_description = metric[METRIC_API_DESCRIPTION_KEY[metric_name]]
@@ -184,6 +186,9 @@ def sync_metric(atx, metric_name, start_date, end_date):
             "metric_description": metric_description,
             **{report_metric["id"]: report_metric["value"] for report_metric in report_metrics}
         }
+
+        if mdata:
+            record = select_fields(mdata, record)
         write_records(metric_name, [record])
 
 
@@ -192,7 +197,17 @@ def write_metrics_state(atx, metric, date_to_resume):
     atx.write_state()
 
 
-def sync_metrics(atx, metric_name):
+def sync_metrics(atx, metric_name, mdata=None):
+    if mdata is None:
+        mdata = {}
+        catalog = getattr(atx, 'catalog', None)
+        streams = getattr(catalog, 'streams', None) if catalog is not None else None
+        if streams is not None:
+            for stream in streams:
+                if getattr(stream, 'tap_stream_id', None) == metric_name:
+                    mdata = singer.metadata.to_map(stream.metadata)
+                    break
+
     bookmark = atx.state.get('bookmarks', {}).get(metric_name, {})
     LOGGER.info('metric: {} '.format(metric_name))
 
@@ -229,7 +244,7 @@ def sync_metrics(atx, metric_name):
         LOGGER.info('ut_current_date: {} '.format(ut_current_date))
         ut_next_date = int(next_date.timestamp())
         LOGGER.info('ut_next_date: {} '.format(ut_next_date))
-        sync_metric(atx, metric_name, ut_current_date, ut_next_date)
+        sync_metric(atx, metric_name, ut_current_date, ut_next_date, mdata)
         # if the prior sync is successful it will write the date_to_resume bookmark
         write_metrics_state(atx, metric_name, next_date)
         current_date = next_date

--- a/tap_frontapp/sync.py
+++ b/tap_frontapp/sync.py
@@ -21,7 +21,15 @@ def sync(atx):
     catalog = atx.catalog
     state = atx.state
 
-    streams_to_sync = [s.tap_stream_id for s in catalog.get_selected_streams(state)]
+    # Use a single source of truth for selected streams. When the
+    # Context has populated ``selected_stream_ids`` from Singer
+    # metadata, prefer that set; otherwise fall back to the catalog's
+    # helper so tests using simple mocks still work.
+    selected_stream_ids = getattr(atx, "selected_stream_ids", None)
+    if selected_stream_ids is not None:
+        streams_to_sync = list(selected_stream_ids)
+    else:
+        streams_to_sync = [s.tap_stream_id for s in catalog.get_selected_streams(state)]
     LOGGER.info("Selected streams: %s", streams_to_sync)
 
     last_stream = singer.get_currently_syncing(state)

--- a/tap_frontapp/sync.py
+++ b/tap_frontapp/sync.py
@@ -28,7 +28,8 @@ def sync(atx):
     LOGGER.info("Currently syncing: %s", last_stream)
 
     for stream_name in STATIC_SCHEMA_STREAM_IDS:
-        load_and_write_schema(stream_name)
+        if stream_name in streams_to_sync:
+            load_and_write_schema(stream_name)
 
     LOGGER.info("Starting sync of selected streams.")
     sync_selected_streams(atx)

--- a/tests/unittests/test_streams.py
+++ b/tests/unittests/test_streams.py
@@ -87,6 +87,40 @@ class TestSyncMetrics(unittest.TestCase):
         sync_metrics(mock_atx, 'test_metric')
         self.assertEqual(mock_write_state.call_count, mock_sync_metric.call_count)
 
+    @patch('tap_frontapp.streams.singer.metadata.to_map')
+    @patch('tap_frontapp.streams.sync_metric')
+    @patch('tap_frontapp.streams.write_metrics_state')
+    def test_sync_metrics_derives_metadata_from_catalog(self, mock_write_state, mock_sync_metric, mock_to_map):
+        """sync_metrics should derive mdata from catalog metadata when not provided."""
+        from tap_frontapp.streams import sync_metrics
+
+        mock_atx = MagicMock()
+        mock_atx.config = {
+            'start_date': '2024-01-01T00:00:00Z',
+            'end_date': '2024-01-01T00:00:00Z',
+        }
+        mock_atx.state = {'bookmarks': {}}
+
+        # Minimal catalog/stream entry with metadata for the metric
+        stream = MagicMock()
+        stream.tap_stream_id = 'test_metric'
+        stream.metadata = 'raw_metadata'
+        mock_catalog = MagicMock()
+        mock_catalog.streams = [stream]
+        mock_atx.catalog = mock_catalog
+
+        derived_mdata = {'from': 'catalog'}
+        mock_to_map.return_value = derived_mdata
+
+        sync_metrics(mock_atx, 'test_metric')
+
+        # Only a single day should be processed for this range
+        mock_sync_metric.assert_called_once()
+        args, _ = mock_sync_metric.call_args
+        # Last positional arg is mdata
+        self.assertIs(args[-1], derived_mdata)
+        mock_to_map.assert_called_once_with(stream.metadata)
+
 
 class TestSyncSelectedStreams(unittest.TestCase):
     """Test sync_selected_streams function"""
@@ -290,6 +324,54 @@ class TestSyncMetric(unittest.TestCase):
         self.assertEqual(records[0]['metric_id'], 'team_123')
         self.assertEqual(records[0]['metric_description'], 'Team A')
         self.assertEqual(records[0]['avg_first_response_time'], 3600)
+
+    @patch('tap_frontapp.streams.write_records')
+    @patch('tap_frontapp.streams.get_report_metrics')
+    @patch('tap_frontapp.streams.create_report')
+    def test_sync_metric_applies_metadata_filtering(self, mock_create_report,
+                                                   mock_get_metrics, mock_write_records):
+        """sync_metric should filter record fields based on Singer metadata map."""
+        from tap_frontapp.streams import sync_metric
+
+        mock_atx = MagicMock()
+        mock_atx.client.list_metrics.return_value = [
+            {'id': 'team_123', 'name': 'Team A'}
+        ]
+        mock_create_report.return_value = 'https://api.frontapp.com/reports/123'
+        mock_get_metrics.return_value = [
+            {'id': 'avg_first_response_time', 'value': 3600},
+            {'id': 'avg_response_time', 'value': 7200},
+        ]
+
+        # Minimal metadata map: keep key properties and one metric field,
+        # drop others (e.g., metric_description and avg_response_time).
+        mdata = {
+            ('properties', 'report_id'): {'inclusion': 'automatic'},
+            ('properties', 'analytics_date'): {'inclusion': 'automatic'},
+            ('properties', 'analytics_range'): {'inclusion': 'automatic'},
+            ('properties', 'metric_id'): {'inclusion': 'automatic'},
+            ('properties', 'avg_first_response_time'): {'selected': True},
+        }
+
+        sync_metric(mock_atx, 'teams_table', 1609459200, 1609545600, mdata)
+
+        mock_write_records.assert_called_once()
+        _, kwargs = mock_write_records.call_args
+        stream_name, records = mock_write_records.call_args[0]
+        self.assertEqual(stream_name, 'teams_table')
+        self.assertEqual(len(records), 1)
+
+        record = records[0]
+        # Key properties / automatic fields are preserved
+        self.assertIn('report_id', record)
+        self.assertIn('analytics_date', record)
+        self.assertIn('analytics_range', record)
+        self.assertIn('metric_id', record)
+        # Selected metric field is preserved
+        self.assertIn('avg_first_response_time', record)
+        # Fields without metadata should be filtered out
+        self.assertNotIn('metric_description', record)
+        self.assertNotIn('avg_response_time', record)
 
     @patch('tap_frontapp.streams.write_records')
     @patch('tap_frontapp.streams.create_report')


### PR DESCRIPTION
# Description of change
Updates the tap to use Singer standard metadata and to better align syncing/schema emission with selected streams, plus adds CI integration testing.
[SAC-28717](https://qlik-dev.atlassian.net/browse/SAC-28717)

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
